### PR TITLE
Fix signed candidate package parsing

### DIFF
--- a/.github/workflows/android-signed-candidate.yml
+++ b/.github/workflows/android-signed-candidate.yml
@@ -168,9 +168,9 @@ jobs:
 
           badging="$("$AAPT" dump badging "$signed_apk")"
           package_line="$(sed -n 's/^package: //p' <<< "$badging")"
-          package_name="$(sed -n "s/.*name='\([^']*\)'.*/\1/p" <<< "$package_line")"
-          version_code="$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<< "$package_line")"
-          version_name="$(sed -n "s/.*versionName='\([^']*\)'.*/\1/p" <<< "$package_line")"
+          package_name="$(sed -n "s/^name='\([^']*\)'.*/\1/p" <<< "$package_line")"
+          version_code="$(sed -n "s/^name='[^']*' versionCode='\([^']*\)'.*/\1/p" <<< "$package_line")"
+          version_name="$(sed -n "s/^name='[^']*' versionCode='[^']*' versionName='\([^']*\)'.*/\1/p" <<< "$package_line")"
           if [ "$package_name" != 'io.dashchan2' ]; then
             echo "::error::Unexpected application ID: $package_name"
             exit 1


### PR DESCRIPTION
## Summary
- anchor signed-candidate APK metadata parsing to the `package:` line fields
- prevent `compileSdkVersionCodename` from being mistaken for the application ID

## Verification
- parser test against the failed run badging output
- `actionlint`
- embedded Bash syntax checks
- `git diff --check`

This PR does not change signing secrets, tags, releases, APK publication, or `update/data.json`.