### PR TITLE
Avoid duplicate Android CI runs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,7 +2,11 @@ name: Android CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       build_scope:


### PR DESCRIPTION
Restrict automatic Android CI push runs to master and pull request runs to master. This prevents the same branch update from starting both push and pull_request builds while preserving manual workflow dispatch.