### PR TITLE
Prepare dedicated F-Droid distribution profile

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -9,6 +9,14 @@ on:
       - master
   workflow_dispatch:
     inputs:
+      distribution:
+        description: Distribution profile
+        required: true
+        default: github
+        type: choice
+        options:
+          - github
+          - fdroid
       build_scope:
         description: Native ABI set
         required: true
@@ -32,6 +40,7 @@ jobs:
     timeout-minutes: 120
     env:
       NATIVE_ABIS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_scope == 'all' && 'arm64-v8a,armeabi-v7a,x86' || 'arm64-v8a' }}
+      BUILD_TASK: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.distribution == 'fdroid' && 'assembleFdroidNdebug' || 'assembleGithubNdebug' }}
 
     steps:
       - name: Check out sources
@@ -74,7 +83,7 @@ jobs:
         run: |
           set -o pipefail
           chmod +x gradlew Dashchan-Webm/*.sh
-          ./gradlew --no-daemon --stacktrace assembleNdebug \
+          ./gradlew --no-daemon --stacktrace "$BUILD_TASK" \
             -PnativePlayerFfmpegFlavor=ffmpeg8 \
             -PnativeAbis="$NATIVE_ABIS" 2>&1 | tee build-main.log
 
@@ -93,7 +102,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: android-ndebug-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_scope || 'arm64' }}-${{ github.run_number }}
+          name: android-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.distribution || 'github' }}-ndebug-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_scope || 'arm64' }}-${{ github.run_number }}
           if-no-files-found: warn
           retention-days: 14
           path: |

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -79,6 +79,22 @@ jobs:
             'build-tools;36.0.0' \
             'ndk;29.0.14206865'
 
+      - name: Prepare F-Droid native source inputs
+        if: env.BUILD_TASK == 'assembleFdroidNdebug'
+        env:
+          DAV1D_VERSION: '1.5.3'
+          FFMPEG_VERSION: '8.1.2'
+          YUV_VERSION: '6afd9becdf58822b1da6770598d8597c583ccfad'
+        run: |
+          set -euo pipefail
+          source_root="$RUNNER_TEMP/fdroid-native-sources"
+          bash Dashchan-Webm/shared-prepare.sh "$source_root"
+          {
+            echo "DASHCHAN_DAV1D_SOURCE_DIR=$source_root/dav1d"
+            echo "DASHCHAN_FFMPEG_SOURCE_DIR=$source_root/ffmpeg"
+            echo "DASHCHAN_LIBYUV_SOURCE_DIR=$source_root/yuv"
+          } >> "$GITHUB_ENV"
+
       - name: Build APK
         run: |
           set -o pipefail

--- a/.github/workflows/android-signed-candidate.yml
+++ b/.github/workflows/android-signed-candidate.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build unsigned all-ABI APK
         run: |
           chmod +x gradlew Dashchan-Webm/*.sh
-          ./gradlew --no-daemon --stacktrace assembleNdebug \
+          ./gradlew --no-daemon --stacktrace assembleGithubNdebug \
             -PnativePlayerFfmpegFlavor=ffmpeg8 \
             -PnativeAbis="$NATIVE_ABIS"
 
@@ -119,7 +119,7 @@ jobs:
             fi
           done
 
-          mapfile -d '' unsigned_apks < <(find build/outputs/apk/ndebug -maxdepth 1 \
+          mapfile -d '' unsigned_apks < <(find build/outputs/apk/github/ndebug -maxdepth 1 \
             -type f -name '*-unsigned.apk' -print0 | sort -z)
           if [ "${#unsigned_apks[@]}" -ne 1 ]; then
             echo "::error::Expected exactly one unsigned APK, found ${#unsigned_apks[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 !/Dashchan-Webm/**
 !/docs
 !/docs/**
+!/distribution
+!/distribution/**
 !/gradle
 !/gradle.properties
 !/gradlew

--- a/CODEX.md
+++ b/CODEX.md
@@ -139,7 +139,7 @@ FAST LOCAL TEST
 Allowed command:
 
 ```sh
-./gradlew assembleNdebug -PnativePlayerFfmpegFlavor=ffmpeg8 -PnativeAbis=arm64-v8a
+./gradlew assembleGithubNdebug -PnativePlayerFfmpegFlavor=ffmpeg8 -PnativeAbis=arm64-v8a
 ```
 
 This mode produces a local test APK only. It must not publish anything.

--- a/Dashchan-Webm/README.md
+++ b/Dashchan-Webm/README.md
@@ -34,6 +34,18 @@ Use the root Gradle Wrapper:
 
 Linux x86_64 or WSL is required. The generated sources and libraries are stored below `Dashchan-Webm/build` and are excluded from Git.
 
+## Pre-provided Native Sources
+
+Build environments that acquire and audit source code before the Gradle build, such as F-Droid, can bypass all network access in `shared-prepare.sh`. Set all three variables to clean source trees at the pinned revisions:
+
+```sh
+export DASHCHAN_DAV1D_SOURCE_DIR=/sources/dav1d-1.5.3
+export DASHCHAN_FFMPEG_SOURCE_DIR=/sources/ffmpeg-8.1.2
+export DASHCHAN_LIBYUV_SOURCE_DIR=/sources/libyuv-6afd9becdf58822b1da6770598d8597c583ccfad
+```
+
+The preparation step copies these trees into its private build directory without VCS metadata. An invalid or missing directory aborts the build. When a variable is unset, the existing pinned download-and-verification path remains in use; ordinary local and GitHub Actions builds therefore keep their current behavior.
+
 ## Standalone Compatibility Module
 
 `Dashchan-Webm/build.gradle` can still produce the historical standalone library package for compatibility testing:

--- a/Dashchan-Webm/README.md
+++ b/Dashchan-Webm/README.md
@@ -27,7 +27,7 @@ The root project invokes:
 Use the root Gradle Wrapper:
 
 ```sh
-./gradlew assembleNdebug \
+./gradlew assembleGithubNdebug \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a,armeabi-v7a,x86
 ```

--- a/Dashchan-Webm/shared-prepare.sh
+++ b/Dashchan-Webm/shared-prepare.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -e -o pipefail
 sources="$1"
 [ -n "$sources" ] || {
 	echo 'Invalid usage' >&2
@@ -17,6 +17,40 @@ sources="$1"
 [ -n "$YUV_VERSION" ] || {
 	echo 'YUV_VERSION is not defined' >&2
 	exit 1
+}
+
+copy_provided_source() {
+	local name="$1"
+	local version="$2"
+	local source="$3"
+	local target="$4"
+	local marker="$target/.dashchan-version"
+	local expected="$name:$version"
+	local source_real target_parent target_real
+	[ -d "$source" ] || {
+		echo "Provided $name source directory does not exist: $source" >&2
+		exit 1
+	}
+	source_real="$(cd "$source" && pwd -P)"
+	mkdir -p "$(dirname "$target")"
+	target_parent="$(cd "$(dirname "$target")" && pwd -P)"
+	target_real="$target_parent/$(basename "$target")"
+	case "$source_real/" in
+		"$target_real/"*)
+			echo "Provided $name source is inside its build target: $source_real" >&2
+			exit 1
+			;;
+	esac
+	case "$target_real/" in
+		"$source_real/"*)
+			echo "Build target for $name is inside the provided source: $target_real" >&2
+			exit 1
+			;;
+	esac
+	rm -rf "$target"
+	mkdir -p "$target"
+	tar -C "$source_real" --exclude='./.git' --exclude='./.git/*' -cf - . | tar -C "$target" -xf -
+	printf '%s\n' "$expected" > "$marker"
 }
 
 # Pinned checksums for stable release archives. libyuv is fetched and verified
@@ -103,13 +137,25 @@ sources_dav1d="$sources/dav1d"
 sources_ffmpeg="$sources/ffmpeg"
 sources_yuv="$sources/yuv"
 
-prepare_source dav1d "$DAV1D_VERSION" \
-	"https://downloads.videolan.org/videolan/dav1d/$DAV1D_VERSION/dav1d-$DAV1D_VERSION.tar.xz" \
-	"$DAV1D_SHA256" "$sources_dav1d" -xJ --touch --strip-components=1
+if [ -n "${DASHCHAN_DAV1D_SOURCE_DIR:-}" ]; then
+	copy_provided_source dav1d "$DAV1D_VERSION" "$DASHCHAN_DAV1D_SOURCE_DIR" "$sources_dav1d"
+else
+	prepare_source dav1d "$DAV1D_VERSION" \
+		"https://downloads.videolan.org/videolan/dav1d/$DAV1D_VERSION/dav1d-$DAV1D_VERSION.tar.xz" \
+		"$DAV1D_SHA256" "$sources_dav1d" -xJ --touch --strip-components=1
+fi
 
-prepare_source ffmpeg "$FFMPEG_VERSION" \
-	"https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.bz2" \
-	"$FFMPEG_SHA256" "$sources_ffmpeg" -xj --touch --strip-components=1
+if [ -n "${DASHCHAN_FFMPEG_SOURCE_DIR:-}" ]; then
+	copy_provided_source ffmpeg "$FFMPEG_VERSION" "$DASHCHAN_FFMPEG_SOURCE_DIR" "$sources_ffmpeg"
+else
+	prepare_source ffmpeg "$FFMPEG_VERSION" \
+		"https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.bz2" \
+		"$FFMPEG_SHA256" "$sources_ffmpeg" -xj --touch --strip-components=1
+fi
 
-prepare_git_source yuv "$YUV_VERSION" \
-	"https://chromium.googlesource.com/libyuv/libyuv" "$sources_yuv"
+if [ -n "${DASHCHAN_LIBYUV_SOURCE_DIR:-}" ]; then
+	copy_provided_source yuv "$YUV_VERSION" "$DASHCHAN_LIBYUV_SOURCE_DIR" "$sources_yuv"
+else
+	prepare_git_source yuv "$YUV_VERSION" \
+		"https://chromium.googlesource.com/libyuv/libyuv" "$sources_yuv"
+fi

--- a/Dashchan-Webm/shared-prepare.sh
+++ b/Dashchan-Webm/shared-prepare.sh
@@ -47,6 +47,7 @@ copy_provided_source() {
 			exit 1
 			;;
 	esac
+	echo "Using provided $name source: $source_real"
 	rm -rf "$target"
 	mkdir -p "$target"
 	tar -C "$source_real" --exclude='./.git' --exclude='./.git/*' -cf - . | tar -C "$target" -xf -

--- a/README.md
+++ b/README.md
@@ -47,16 +47,17 @@ Slooop - пользовательское название неофициаль�
 Необходимы JDK 17+, Android SDK Platform 37, Build Tools 36.0.0, NDK 29.0.14206865 и Linux x86_64/WSL для нативных библиотек. Gradle Wrapper загружает Gradle 9.4.1.
 
 ```sh
-./gradlew assembleNdebug \
+./gradlew assembleGithubNdebug \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a,armeabi-v7a,x86
 ```
 
-APK появится в `build/outputs/apk`. Первая сборка скачивает исходники FFmpeg, dav1d и libyuv и может занять заметное время. Репозиторий не содержит приватный ключ публикации и не создаёт официальный подписанный APK автоматически.
+APK появится в `build/outputs/apk`. Первая сборка скачивает исходники FFmpeg, dav1d и libyuv и может занять заметное время. Репозиторий не содержит приватный ключ публикации. Защищённый ручной workflow может создать временный подписанный кандидат, но ничего не публикует автоматически.
 
 Подробные инструкции:
 
 - [Сборка и окружение](docs/BUILDING.md)
+- [Подготовка сборки F-Droid](docs/FDROID.md)
 - [Подписание APK](docs/SIGNING.md)
 - [Обновление NDK 29](docs/NDK_UPGRADE_R29.md)
 - [Проверки и автоматизация](docs/CI.md)
@@ -123,12 +124,12 @@ Stable APKs are published only through [GitHub Releases](https://github.com/andr
 Install JDK 17+, Android SDK Platform 37, Build Tools 36.0.0, NDK 29.0.14206865, and use Linux x86_64 or WSL for native libraries. The Gradle Wrapper downloads Gradle 9.4.1.
 
 ```sh
-./gradlew assembleNdebug \
+./gradlew assembleGithubNdebug \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a,armeabi-v7a,x86
 ```
 
-The APK is written under `build/outputs/apk`. The first build downloads FFmpeg, dav1d, and libyuv sources. The repository does not contain the private release key and does not automatically produce the official signed APK.
+The APK is written under `build/outputs/apk`. The first build downloads FFmpeg, dav1d, and libyuv sources. The repository does not contain the private release key. A protected manual workflow can create a temporary signed candidate, but it never publishes a release automatically.
 
 See [docs/BUILDING.md](docs/BUILDING.md), [docs/TESTING.md](docs/TESTING.md), and [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md) for the complete workflow.
 

--- a/build.gradle
+++ b/build.gradle
@@ -158,10 +158,6 @@ android {
 		}
 
 		buildConfigField 'String', 'VERSION_DATE', '"' + versions[0].date + '"'
-		buildConfigField 'String', 'URI_UPDATES', '"//raw.githubusercontent.com/' +
-				'andrewpozdnakov7-jpg/Dashchan_2/master/update/data.json"'
-		buildConfigField 'String', 'URI_UPDATES_BETA', '"//raw.githubusercontent.com/' +
-				'andrewpozdnakov7-jpg/Dashchan_2_Update_Test/master/update/data.json"'
 		buildConfigField 'String', 'URI_THEMES', '"//raw.githubusercontent.com/' +
 				'andrewpozdnakov7-jpg/Dashchan_2/master/update/themes.json"'
 		buildConfigField 'String', 'GITHUB_URI_METADATA', '"//github.com/andrewpozdnakov7-jpg/Dashchan_2"'
@@ -171,14 +167,6 @@ android {
 		buildConfigField 'String', 'GITHUB_PATH_METADATA_BETA', '"metadata"'
 		buildConfigField 'String', 'FILE_PROVIDER_AUTHORITY', '"' +
 				manifestPlaceholders.fileProviderAuthority + '"'
-		buildConfigField 'String', 'UPDATE_MANIFEST_URL', '""'
-		buildConfigField 'String', 'UPDATE_MANIFEST_BETA_URL', '""'
-		buildConfigField 'String', 'UPDATE_GITHUB_RELEASES_URL',
-				'"https://api.github.com/repos/andrewpozdnakov7-jpg/Dashchan_2/releases"'
-		buildConfigField 'String', 'UPDATE_GITHUB_LATEST_RELEASE_URL', '""'
-		buildConfigField 'String', 'UPDATE_GITHUB_BETA_RELEASES_URL',
-				'"https://api.github.com/repos/andrewpozdnakov7-jpg/Dashchan_2_Update_Test/releases"'
-		buildConfigField 'String', 'UPDATE_GITHUB_BETA_LATEST_RELEASE_URL', '""'
 		buildConfigField 'String', 'CHAN_EXTENSION_FEATURE_NAME', '"chan.extension"'
 		buildConfigField 'String', 'LIB_EXTENSION_FEATURE_NAME', '"lib.extension"'
 		buildConfigField 'String', 'LIB_WEBM_EXTENSION_NAME', '"webm"'
@@ -191,6 +179,40 @@ android {
 				buildConfigStringArray(knownLibExtensionPackages)
 	}
 
+	flavorDimensions += 'distribution'
+	productFlavors {
+		github {
+			dimension = 'distribution'
+			buildConfigField 'boolean', 'ALLOW_GMS_SECURITY_PROVIDER', 'true'
+			buildConfigField 'boolean', 'ALLOW_APPLICATION_SELF_UPDATE', 'true'
+			buildConfigField 'String', 'URI_UPDATES', '"//raw.githubusercontent.com/' +
+					'andrewpozdnakov7-jpg/Dashchan_2/master/update/data.json"'
+			buildConfigField 'String', 'URI_UPDATES_BETA', '"//raw.githubusercontent.com/' +
+					'andrewpozdnakov7-jpg/Dashchan_2_Update_Test/master/update/data.json"'
+			buildConfigField 'String', 'UPDATE_MANIFEST_URL', '""'
+			buildConfigField 'String', 'UPDATE_MANIFEST_BETA_URL', '""'
+			buildConfigField 'String', 'UPDATE_GITHUB_RELEASES_URL',
+					'"https://api.github.com/repos/andrewpozdnakov7-jpg/Dashchan_2/releases"'
+			buildConfigField 'String', 'UPDATE_GITHUB_LATEST_RELEASE_URL', '""'
+			buildConfigField 'String', 'UPDATE_GITHUB_BETA_RELEASES_URL',
+					'"https://api.github.com/repos/andrewpozdnakov7-jpg/Dashchan_2_Update_Test/releases"'
+			buildConfigField 'String', 'UPDATE_GITHUB_BETA_LATEST_RELEASE_URL', '""'
+		}
+		fdroid {
+			dimension = 'distribution'
+			buildConfigField 'boolean', 'ALLOW_GMS_SECURITY_PROVIDER', 'false'
+			buildConfigField 'boolean', 'ALLOW_APPLICATION_SELF_UPDATE', 'false'
+			buildConfigField 'String', 'URI_UPDATES', '""'
+			buildConfigField 'String', 'URI_UPDATES_BETA', '""'
+			buildConfigField 'String', 'UPDATE_MANIFEST_URL', '""'
+			buildConfigField 'String', 'UPDATE_MANIFEST_BETA_URL', '""'
+			buildConfigField 'String', 'UPDATE_GITHUB_RELEASES_URL', '""'
+			buildConfigField 'String', 'UPDATE_GITHUB_LATEST_RELEASE_URL', '""'
+			buildConfigField 'String', 'UPDATE_GITHUB_BETA_RELEASES_URL', '""'
+			buildConfigField 'String', 'UPDATE_GITHUB_BETA_LATEST_RELEASE_URL', '""'
+		}
+	}
+
 	sourceSets.main {
 		manifest.srcFile 'AndroidManifest.xml'
 		java.srcDirs = ['src']
@@ -201,6 +223,8 @@ android {
 		jni.srcDirs = []
 		jniLibs.srcDirs = []
 	}
+	sourceSets.github.java.srcDir 'distribution/github/src'
+	sourceSets.fdroid.java.srcDir 'distribution/fdroid/src'
 	sourceSets.test {
 		java.srcDirs = ['unitTests/src']
 		resources.srcDirs = ['unitTests/resources']

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,11 @@ def builtinWebmLibrariesPattern = [
 		'/lib/*/libswscale.so',
 		'/lib/*/libyuv.so'
 ]
+def builtinWebmProvidedSourceDirectories = [
+		dav1d: providers.environmentVariable('DASHCHAN_DAV1D_SOURCE_DIR'),
+		ffmpeg: providers.environmentVariable('DASHCHAN_FFMPEG_SOURCE_DIR'),
+		libyuv: providers.environmentVariable('DASHCHAN_LIBYUV_SOURCE_DIR')
+]
 def getAndroidSdkDirectory = {
 	def localProperties = new Properties()
 	def localPropertiesFile = rootProject.file('local.properties')
@@ -308,6 +313,12 @@ tasks.register('prepareBuiltinWebmSources', Exec) {
 	inputs.property 'dav1dVersion', '1.5.3'
 	inputs.property 'ffmpegVersion', '8.1.2'
 	inputs.property 'yuvVersion', '6afd9becdf58822b1da6770598d8597c583ccfad'
+	builtinWebmProvidedSourceDirectories.each { name, directory ->
+		inputs.property "${name}ProvidedSourceDirectory", directory.orElse('')
+		if (directory.isPresent()) {
+			inputs.dir directory
+		}
+	}
 	outputs.dir builtinWebmSources
 	doFirst {
 		requireUnixBuiltinWebmBuild()

--- a/distribution/fdroid/src/chan/http/SecurityProviderInstaller.java
+++ b/distribution/fdroid/src/chan/http/SecurityProviderInstaller.java
@@ -1,0 +1,7 @@
+package chan.http;
+
+final class SecurityProviderInstaller {
+	private SecurityProviderInstaller() {}
+
+	public static void installIfEnabled() {}
+}

--- a/distribution/github/src/chan/http/SecurityProviderInstaller.java
+++ b/distribution/github/src/chan/http/SecurityProviderInstaller.java
@@ -1,0 +1,27 @@
+package chan.http;
+
+import android.content.Context;
+import com.mishiranu.dashchan.content.MainApplication;
+import com.mishiranu.dashchan.content.Preferences;
+import java.lang.reflect.Method;
+
+final class SecurityProviderInstaller {
+	private SecurityProviderInstaller() {}
+
+	public static void installIfEnabled() {
+		if (!Preferences.isUseGmsProvider()) {
+			return;
+		}
+		try {
+			// Load GmsCore_OpenSSL from Google Play Services package.
+			Context context = MainApplication.getInstance().createPackageContext("com.google.android.gms",
+					Context.CONTEXT_IGNORE_SECURITY | Context.CONTEXT_INCLUDE_CODE);
+			Class<?> providerInstallerImplClass = Class.forName("com.google.android.gms.common.security"
+					+ ".ProviderInstallerImpl", false, context.getClassLoader());
+			Method insertProviderMethod = providerInstallerImplClass.getMethod("insertProvider", Context.class);
+			insertProviderMethod.invoke(null, context);
+		} catch (Exception e) {
+			// The provider is optional; keep the platform provider when it is unavailable.
+		}
+	}
+}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -20,7 +20,7 @@ Set `ANDROID_HOME` or `ANDROID_SDK_ROOT`, or create an untracked `local.properti
 Use the checked-in Gradle Wrapper:
 
 ```sh
-./gradlew assembleNdebug \
+./gradlew assembleGithubNdebug \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a,armeabi-v7a,x86
 ```
@@ -30,18 +30,28 @@ The first run executes `prepareBuiltinWebmSources` and `buildBuiltinWebmLibrarie
 To build only one ABI for a quick device test:
 
 ```sh
-./gradlew assembleNdebug \
+./gradlew assembleGithubNdebug \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a
 ```
 
 APK outputs are written under `build/outputs/apk`. Native intermediates are kept under `Dashchan-Webm/build` and `.cxx` and can be reused by later builds.
 
+The F-Droid distribution uses the same application ID and source tree but removes application self-update endpoints and the optional GMS security-provider path:
+
+```sh
+./gradlew assembleFdroidNdebug \
+  -PnativePlayerFfmpegFlavor=ffmpeg8 \
+  -PnativeAbis=arm64-v8a,armeabi-v7a,x86
+```
+
+See [FDROID.md](FDROID.md) for the pre-provided native-source variables required by a network-free F-Droid recipe.
+
 ## Unit Tests And Static Checks
 
 ```sh
 ./gradlew test
-./gradlew lintNdebug
+./gradlew lintGithubNdebug
 ```
 
 The unit-test set is intentionally small; a release still requires the manual checks in [TESTING.md](TESTING.md).
@@ -50,7 +60,7 @@ The unit-test set is intentionally small; a release still requires the manual ch
 
 ```sh
 ./gradlew clean
-./gradlew assembleNdebug \
+./gradlew assembleGithubNdebug \
   --no-configuration-cache \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a,armeabi-v7a,x86

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,6 +1,6 @@
 # Checks And Automation
 
-`Android CI` automatically builds the `github` arm64 variant for pull requests and `master`. A manual run can select either the `github` or `fdroid` distribution and arm64 or all supported ABIs. These APKs are unsigned test artifacts and are never published as releases.
+`Android CI` automatically builds the `github` arm64 variant for pull requests and `master`. A manual run can select either the `github` or `fdroid` distribution and arm64 or all supported ABIs. For `fdroid`, CI acquires the pinned native sources before Gradle and passes them through the pre-provided source interface, exercising the same network-free Gradle path expected by fdroiddata. These APKs are unsigned test artifacts and are never published as releases.
 
 The protected `Android Signed Candidate` workflow builds and signs only the `github` all-ABI variant from `master`. It uploads a temporary candidate artifact after package, version, ABI, alignment, certificate, and checksum validation. It does not create tags, GitHub Releases, or update public metadata.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,6 +1,8 @@
 # Checks And Automation
 
-The repository currently does not publish APKs through GitHub Actions. Release APKs are built on a controlled Linux/WSL machine, tested on a device, audited, and uploaded manually.
+`Android CI` automatically builds the `github` arm64 variant for pull requests and `master`. A manual run can select either the `github` or `fdroid` distribution and arm64 or all supported ABIs. These APKs are unsigned test artifacts and are never published as releases.
+
+The protected `Android Signed Candidate` workflow builds and signs only the `github` all-ABI variant from `master`. It uploads a temporary candidate artifact after package, version, ABI, alignment, certificate, and checksum validation. It does not create tags, GitHub Releases, or update public metadata.
 
 ## Required Local Checks
 
@@ -8,8 +10,8 @@ Run from the repository root:
 
 ```sh
 ./gradlew test
-./gradlew lintNdebug
-./gradlew assembleNdebug \
+./gradlew lintGithubNdebug
+./gradlew assembleGithubNdebug \
   -PnativePlayerFfmpegFlavor=ffmpeg8 \
   -PnativeAbis=arm64-v8a,armeabi-v7a,x86
 ```
@@ -23,6 +25,6 @@ Also verify:
 - certificate, package name, version, permissions, and SHA-256 are expected;
 - no local paths, usernames, IP addresses, credentials, or private keys appear in release artifacts.
 
-## Future GitHub Actions
+## Release Boundary
 
-A future workflow may run Java tests, JSON validation, documentation-link checks, and non-native lint. Official signing should remain outside public CI unless a carefully reviewed secret-management process is introduced. Pull requests must not require access to release secrets.
+Pull requests never receive release secrets. A successful CI or signed-candidate run does not authorize publication; the explicit release modes and checks in `CODEX.md` still apply.

--- a/docs/FDROID.md
+++ b/docs/FDROID.md
@@ -1,0 +1,21 @@
+# F-Droid Build Preparation
+
+Slooop uses `io.dashchan2` as its application ID and is licensed under GPL-3.0-or-later. The normal GitHub distribution and the future F-Droid distribution are built from the same repository and release tags.
+
+## Native source policy
+
+The player builds FFmpeg 8.1.2, dav1d 1.5.3, and libyuv commit `6afd9becdf58822b1da6770598d8597c583ccfad` from source. A regular build downloads these pinned sources and verifies the release archives or exact Git commit.
+
+For an F-Droid build, the fdroiddata recipe must acquire the three source trees before Gradle starts and expose them through:
+
+- `DASHCHAN_DAV1D_SOURCE_DIR`
+- `DASHCHAN_FFMPEG_SOURCE_DIR`
+- `DASHCHAN_LIBYUV_SOURCE_DIR`
+
+All three variables are required for the network-free F-Droid path. `Dashchan-Webm/shared-prepare.sh` copies the supplied trees into the isolated Gradle build directory and does not invoke `curl` or `git` for those components.
+
+## Planned distribution profile
+
+A later source change will add a dedicated F-Droid build profile. It will preserve the `io.dashchan2` application ID while excluding the optional Google Play Services security-provider integration and the GitHub application self-updater. The normal GitHub build will retain its current behavior.
+
+The final fdroiddata recipe, anti-feature declarations, screenshots, and reproducible-build comparison are intentionally handled after the source-only F-Droid profile is complete.

--- a/docs/FDROID.md
+++ b/docs/FDROID.md
@@ -14,8 +14,11 @@ For an F-Droid build, the fdroiddata recipe must acquire the three source trees 
 
 All three variables are required for the network-free F-Droid path. `Dashchan-Webm/shared-prepare.sh` copies the supplied trees into the isolated Gradle build directory and does not invoke `curl` or `git` for those components.
 
-## Planned distribution profile
+## Distribution profiles
 
-A later source change will add a dedicated F-Droid build profile. It will preserve the `io.dashchan2` application ID while excluding the optional Google Play Services security-provider integration and the GitHub application self-updater. The normal GitHub build will retain its current behavior.
+The `github` and `fdroid` product flavors share the same source code and `io.dashchan2` application ID:
 
-The final fdroiddata recipe, anti-feature declarations, screenshots, and reproducible-build comparison are intentionally handled after the source-only F-Droid profile is complete.
+- `assembleGithubNdebug` retains the optional Google Play Services security provider, application update channels, automatic update checks, and package installer used by the existing GitHub distribution;
+- `assembleFdroidNdebug` uses a no-op security-provider source set, excludes the GMS option and application self-update interface, forces automatic update checks off even for migrated preferences, removes upstream application-update endpoints, and rejects client APK requests in the shared updater. The package installer remains available internally for separately installed imageboard extensions.
+
+The final fdroiddata recipe must invoke `assembleFdroidNdebug`. Anti-feature declarations, screenshots, and reproducible-build comparison are handled after this source profile is validated.

--- a/docs/GRADLE_CONFIGURATION_CACHE.md
+++ b/docs/GRADLE_CONFIGURATION_CACHE.md
@@ -8,7 +8,7 @@ Run normal tasks without extra flags. Gradle will report whether the configurati
 
 ```sh
 ./gradlew test
-./gradlew assembleNdebug -PnativePlayerFfmpegFlavor=ffmpeg8 -PnativeAbis=arm64-v8a
+./gradlew assembleGithubNdebug -PnativePlayerFfmpegFlavor=ffmpeg8 -PnativeAbis=arm64-v8a
 ```
 
 ## Troubleshooting

--- a/src/chan/http/HttpClient.java
+++ b/src/chan/http/HttpClient.java
@@ -10,7 +10,6 @@ import chan.content.Chan;
 import chan.util.CommonUtils;
 import chan.util.StringUtils;
 import com.mishiranu.dashchan.content.AdvancedPreferences;
-import com.mishiranu.dashchan.content.MainApplication;
 import com.mishiranu.dashchan.content.Preferences;
 import com.mishiranu.dashchan.content.model.ErrorItem;
 import com.mishiranu.dashchan.util.IOUtils;
@@ -27,7 +26,6 @@ import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.SequenceInputStream;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Method;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.HttpURLConnection;
@@ -91,19 +89,7 @@ public class HttpClient {
 		SHORT_RESPONSE_MESSAGES.put("Internal Server Error", "Internal Error");
 		SHORT_RESPONSE_MESSAGES.put("Service Temporarily Unavailable", "Service Unavailable");
 
-		if (Preferences.isUseGmsProvider()) {
-			try {
-				// Load GmsCore_OpenSSL from Google Play Services package
-				Context context = MainApplication.getInstance().createPackageContext("com.google.android.gms",
-						Context.CONTEXT_IGNORE_SECURITY | Context.CONTEXT_INCLUDE_CODE);
-				Class<?> providerInstallerImplClass = Class.forName("com.google.android.gms.common.security"
-						+ ".ProviderInstallerImpl", false, context.getClassLoader());
-				Method insertProviderMethod = providerInstallerImplClass.getMethod("insertProvider", Context.class);
-				insertProviderMethod.invoke(null, context);
-			} catch (Exception e) {
-				// Reflective operation, ignore exception
-			}
-		}
+		SecurityProviderInstaller.installIfEnabled();
 
 		/*
 		 * MediaPlayer uses MediaHTTPConnection that uses its own CookieHandler instance.

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -16,6 +16,7 @@ import chan.content.Chan;
 import chan.content.ChanConfiguration;
 import chan.content.ChanManager;
 import chan.util.StringUtils;
+import com.mishiranu.dashchan.BuildConfig;
 import com.mishiranu.dashchan.C;
 import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.util.SharedPreferences;
@@ -615,6 +616,9 @@ public class Preferences {
 	public static final boolean DEFAULT_UPDATE_AUTO_CHECK_ENABLED = true;
 
 	public static boolean isUpdateAutoCheckEnabled() {
+		if (!BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
+			return false;
+		}
 		if (PREFERENCES.getAll().containsKey(KEY_UPDATE_AUTO_CHECK_ENABLED)) {
 			return PREFERENCES.getBoolean(KEY_UPDATE_AUTO_CHECK_ENABLED, DEFAULT_UPDATE_AUTO_CHECK_ENABLED);
 		}
@@ -622,6 +626,9 @@ public class Preferences {
 	}
 
 	public static void setUpdateAutoCheckEnabled(boolean updateAutoCheckEnabled) {
+		if (!BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
+			return;
+		}
 		PREFERENCES.edit()
 				.put(KEY_UPDATE_AUTO_CHECK_ENABLED, updateAutoCheckEnabled)
 				.put(KEY_CHECK_UPDATES_ON_START, updateAutoCheckEnabled)
@@ -1686,7 +1693,8 @@ public class Preferences {
 	public static final boolean DEFAULT_USE_GMS_PROVIDER = false;
 
 	public static boolean isUseGmsProvider() {
-		return PREFERENCES.getBoolean(KEY_USE_GMS_PROVIDER, DEFAULT_USE_GMS_PROVIDER);
+		return BuildConfig.ALLOW_GMS_SECURITY_PROVIDER &&
+				PREFERENCES.getBoolean(KEY_USE_GMS_PROVIDER, DEFAULT_USE_GMS_PROVIDER);
 	}
 
 	public static final ChanKey KEY_USE_HTTPS = new ChanKey("use_https");

--- a/src/com/mishiranu/dashchan/content/UpdaterActivity.java
+++ b/src/com/mishiranu/dashchan/content/UpdaterActivity.java
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationCompat;
 import chan.content.ChanManager;
 import chan.util.DataFile;
 import chan.util.StringUtils;
+import com.mishiranu.dashchan.BuildConfig;
 import com.mishiranu.dashchan.C;
 import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.content.service.DownloadService;
@@ -240,6 +241,10 @@ public class UpdaterActivity extends StateActivity {
 		DownloadService.DownloadItem clientDownloadItem = null;
 		ArrayList<DownloadService.DownloadItem> downloadItems = new ArrayList<>();
 		for (Request request : requests) {
+			if (!BuildConfig.ALLOW_APPLICATION_SELF_UPDATE &&
+					ChanManager.EXTENSION_NAME_CLIENT.equals(request.extensionName)) {
+				continue;
+			}
 			String name = request.extensionName + "-" + request.versionName + ".apk";
 			DownloadService.DownloadItem downloadItem = new DownloadService.DownloadItem(null,
 					request.uri, name, request.sha256sum, request.checkFingerprints);
@@ -251,6 +256,9 @@ public class UpdaterActivity extends StateActivity {
 		}
 		if (clientDownloadItem != null) {
 			downloadItems.add(clientDownloadItem);
+		}
+		if (downloadItems.isEmpty()) {
+			return;
 		}
 		if (activeConnection != null) {
 			activeConnection.cancel();

--- a/src/com/mishiranu/dashchan/content/update/UpdateDialogHelper.java
+++ b/src/com/mishiranu/dashchan/content/update/UpdateDialogHelper.java
@@ -134,7 +134,7 @@ public class UpdateDialogHelper {
 						}
 					}
 				});
-		if (context instanceof FragmentHandler) {
+		if (BuildConfig.ALLOW_APPLICATION_SELF_UPDATE && context instanceof FragmentHandler) {
 			builder.setPositiveButton(R.string.open_updates, (dialog, which) ->
 					((FragmentHandler) context).pushFragment(new UpdateFragment()));
 		}

--- a/src/com/mishiranu/dashchan/ui/preference/AboutFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/AboutFragment.java
@@ -61,38 +61,40 @@ public class AboutFragment extends PreferenceFragment implements FragmentHandler
 		addButton(R.string.changelog, 0)
 				.setOnClickListener(p -> ((FragmentHandler) requireActivity())
 						.pushFragment(new TextFragment(TextFragment.Type.CHANGELOG)));
-		ListPreference updateChannelPreference = addList(Preferences.KEY_UPDATE_CHANNEL,
-				enumList(Preferences.UpdateChannel.values(), channel -> channel.value),
-				Preferences.DEFAULT_UPDATE_CHANNEL.value, R.string.update_channel,
-				enumResList(Preferences.UpdateChannel.values(), channel -> channel.titleResId));
-		updateChannelPreference.setOnBeforeChangeListener((preference, value) -> {
-			if (!confirmingBetaChannel && Preferences.UpdateChannel.BETA.value.equals(value) &&
-					!Preferences.UpdateChannel.BETA.value.equals(preference.getValue())) {
-				new AlertDialog.Builder(requireContext())
-						.setTitle(R.string.update_channel_beta)
-						.setMessage(R.string.beta_update_channel_warning__sentence)
-						.setNegativeButton(android.R.string.cancel, null)
-						.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-							confirmingBetaChannel = true;
-							preference.setValue(value);
-							confirmingBetaChannel = false;
-						})
-						.show();
-				return false;
-			}
-			return true;
-		});
-		updateChannelPreference.setOnAfterChangeListener(preference -> {
-			Preferences.resetUpdatePromptState();
-			((FragmentHandler) requireActivity()).pushFragment(new UpdateFragment());
-		});
-		CheckPreference automaticUpdateCheck = addCheck(false, Preferences.KEY_UPDATE_AUTO_CHECK_ENABLED,
-				Preferences.isUpdateAutoCheckEnabled(), R.string.automatic_update_check, 0);
-		automaticUpdateCheck.setOnAfterChangeListener(preference ->
-				Preferences.setUpdateAutoCheckEnabled(preference.getValue()));
-		addButton(R.string.check_for_updates, 0)
-				.setOnClickListener(p -> ((FragmentHandler) requireActivity())
-						.pushFragment(new UpdateFragment()));
+		if (BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
+			ListPreference updateChannelPreference = addList(Preferences.KEY_UPDATE_CHANNEL,
+					enumList(Preferences.UpdateChannel.values(), channel -> channel.value),
+					Preferences.DEFAULT_UPDATE_CHANNEL.value, R.string.update_channel,
+					enumResList(Preferences.UpdateChannel.values(), channel -> channel.titleResId));
+			updateChannelPreference.setOnBeforeChangeListener((preference, value) -> {
+				if (!confirmingBetaChannel && Preferences.UpdateChannel.BETA.value.equals(value) &&
+						!Preferences.UpdateChannel.BETA.value.equals(preference.getValue())) {
+					new AlertDialog.Builder(requireContext())
+							.setTitle(R.string.update_channel_beta)
+							.setMessage(R.string.beta_update_channel_warning__sentence)
+							.setNegativeButton(android.R.string.cancel, null)
+							.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+								confirmingBetaChannel = true;
+								preference.setValue(value);
+								confirmingBetaChannel = false;
+							})
+							.show();
+					return false;
+				}
+				return true;
+			});
+			updateChannelPreference.setOnAfterChangeListener(preference -> {
+				Preferences.resetUpdatePromptState();
+				((FragmentHandler) requireActivity()).pushFragment(new UpdateFragment());
+			});
+			CheckPreference automaticUpdateCheck = addCheck(false, Preferences.KEY_UPDATE_AUTO_CHECK_ENABLED,
+					Preferences.isUpdateAutoCheckEnabled(), R.string.automatic_update_check, 0);
+			automaticUpdateCheck.setOnAfterChangeListener(preference ->
+					Preferences.setUpdateAutoCheckEnabled(preference.getValue()));
+			addButton(R.string.check_for_updates, 0)
+					.setOnClickListener(p -> ((FragmentHandler) requireActivity())
+							.pushFragment(new UpdateFragment()));
+		}
 		addButton(getString(R.string.project_author), PROJECT_AUTHOR)
 				.setOnClickListener(p -> NavigationUtils.openSystemBrowser(requireContext(),
 						Uri.parse("https:" + BuildConfig.GITHUB_URI_METADATA)));

--- a/src/com/mishiranu/dashchan/ui/preference/ExperimentalFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/ExperimentalFragment.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.os.Bundle;
 import android.view.View;
 import androidx.annotation.NonNull;
+import com.mishiranu.dashchan.BuildConfig;
 import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.content.Preferences;
 import com.mishiranu.dashchan.media.VideoDiagnostics;
@@ -59,8 +60,10 @@ public class ExperimentalFragment extends PreferenceFragment {
 		audioBoostLevelPreference.setEnabled(audioBoostPreference.getValue());
 		audioBoostPreference.setOnAfterChangeListener(p -> refreshPreferences());
 		addHeader(R.string.additional);
-		addCheck(true, Preferences.KEY_USE_GMS_PROVIDER, Preferences.DEFAULT_USE_GMS_PROVIDER,
-				R.string.use_gms_security_provider, R.string.use_gms_security_provider__summary);
+		if (BuildConfig.ALLOW_GMS_SECURITY_PROVIDER) {
+			addCheck(true, Preferences.KEY_USE_GMS_PROVIDER, Preferences.DEFAULT_USE_GMS_PROVIDER,
+					R.string.use_gms_security_provider, R.string.use_gms_security_provider__summary);
+		}
 	}
 
 	private void addVideoDiagnosticsPreferences() {

--- a/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
+++ b/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
@@ -6,6 +6,7 @@ import chan.content.Chan;
 import chan.content.ChanConfiguration;
 import chan.content.ChanManager;
 import chan.util.StringUtils;
+import com.mishiranu.dashchan.BuildConfig;
 import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.content.Preferences;
 import com.mishiranu.dashchan.ui.ContentFragment;
@@ -303,8 +304,10 @@ public final class SettingsSearchIndex {
 				R.string.video_audio_boost__summary, Preferences.KEY_VIDEO_AUDIO_BOOST);
 		add(context, entries, Screen.EXPERIMENTAL, R.string.video_audio_boost_level, 0,
 				Preferences.KEY_VIDEO_AUDIO_BOOST_DB);
-		add(context, entries, Screen.EXPERIMENTAL, R.string.use_gms_security_provider,
-				R.string.use_gms_security_provider__summary, Preferences.KEY_USE_GMS_PROVIDER);
+		if (BuildConfig.ALLOW_GMS_SECURITY_PROVIDER) {
+			add(context, entries, Screen.EXPERIMENTAL, R.string.use_gms_security_provider,
+					R.string.use_gms_security_provider__summary, Preferences.KEY_USE_GMS_PROVIDER);
+		}
 		add(context, entries, Screen.EXPERIMENTAL, R.string.video_diagnostics_start,
 				R.string.video_diagnostics_start__summary, null);
 
@@ -448,10 +451,12 @@ public final class SettingsSearchIndex {
 		add(context, entries, Screen.ABOUT, R.string.statistics);
 		add(context, entries, Screen.ABOUT, R.string.backup_data, R.string.backup_data__summary, null);
 		add(context, entries, Screen.ABOUT, R.string.changelog);
-		add(context, entries, Screen.ABOUT, R.string.update_channel, 0, Preferences.KEY_UPDATE_CHANNEL);
-		add(context, entries, Screen.ABOUT, R.string.automatic_update_check, 0,
-				Preferences.KEY_UPDATE_AUTO_CHECK_ENABLED);
-		add(context, entries, Screen.ABOUT, R.string.check_for_updates);
+		if (BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
+			add(context, entries, Screen.ABOUT, R.string.update_channel, 0, Preferences.KEY_UPDATE_CHANNEL);
+			add(context, entries, Screen.ABOUT, R.string.automatic_update_check, 0,
+					Preferences.KEY_UPDATE_AUTO_CHECK_ENABLED);
+			add(context, entries, Screen.ABOUT, R.string.check_for_updates);
+		}
 		add(context, entries, Screen.ABOUT, R.string.project_author);
 		add(context, entries, Screen.ABOUT, R.string.based_on_dashchan, R.string.based_on_dashchan__summary, null);
 		add(context, entries, Screen.ABOUT, R.string.contact_email);

--- a/src/com/mishiranu/dashchan/ui/preference/UpdateFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/UpdateFragment.java
@@ -24,6 +24,7 @@ import chan.content.Chan;
 import chan.content.ChanManager;
 import chan.util.CommonUtils;
 import chan.util.StringUtils;
+import com.mishiranu.dashchan.BuildConfig;
 import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.content.UpdaterActivity;
 import com.mishiranu.dashchan.content.async.ReadUpdateTask;
@@ -337,26 +338,29 @@ public class UpdateFragment extends BaseListFragment {
 		int maxApiVersion;
 		{
 			ReadUpdateTask.ApplicationItem applicationItem = updateDataMap.get(ChanManager.EXTENSION_NAME_CLIENT, true);
-			ListItem listItem = new ListItem(ChanManager.EXTENSION_NAME_CLIENT,
-					context != null ? AndroidUtils.getApplicationLabel(context) : null,
-					applicationItem.packageItems.size() >= 2, true);
-			int targetIndex = savedInstanceState != null ? savedInstanceState.getInt(EXTRA_TARGET_PREFIX
-					+ listItem.extensionName, -1) : -1;
-			if (targetIndex < 0) {
-				targetIndex = 0;
-				for (int i = 1; i < applicationItem.packageItems.size(); i++) {
-					ReadUpdateTask.PackageItem updatePackageItem = applicationItem.packageItems.get(i);
-					if (shouldSelectUpdate(applicationItem.packageItems.get(0), updatePackageItem)) {
-						targetIndex = i;
-						break;
+			int targetIndex = 0;
+			if (BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
+				ListItem listItem = new ListItem(ChanManager.EXTENSION_NAME_CLIENT,
+						context != null ? AndroidUtils.getApplicationLabel(context) : null,
+						applicationItem.packageItems.size() >= 2, true);
+				targetIndex = savedInstanceState != null ? savedInstanceState.getInt(EXTRA_TARGET_PREFIX
+						+ listItem.extensionName, -1) : -1;
+				if (targetIndex < 0) {
+					targetIndex = 0;
+					for (int i = 1; i < applicationItem.packageItems.size(); i++) {
+						ReadUpdateTask.PackageItem updatePackageItem = applicationItem.packageItems.get(i);
+						if (shouldSelectUpdate(applicationItem.packageItems.get(0), updatePackageItem)) {
+							targetIndex = i;
+							break;
+						}
 					}
 				}
+				listItem.setTarget(context, applicationItem, targetIndex);
+				listItems.add(listItem);
 			}
-			listItem.setTarget(context, applicationItem, targetIndex);
 			ReadUpdateTask.PackageItem currentApplicationPackageItem = applicationItem.packageItems.get(targetIndex);
 			minApiVersion = currentApplicationPackageItem.minApiVersion;
 			maxApiVersion = currentApplicationPackageItem.maxApiVersion;
-			listItems.add(listItem);
 		}
 		handledExtensionNames.add(ChanManager.EXTENSION_NAME_CLIENT);
 		ChanManager manager = ChanManager.getInstance();


### PR DESCRIPTION
## Summary

- support pinned offline FFmpeg, dav1d, and libyuv source trees
- add separate GitHub and F-Droid distribution profiles
- disable client self-updates and GMS security-provider installation in the F-Droid profile
- allow manual unsigned F-Droid CI builds

## Validation plan

- required automatic Ndebug (arm64) check for the GitHub profile
- manual Android CI run with distribution=fdroid and uild_scope=arm64`n
This PR must not be merged until both builds are successful and their artifacts are verified.