### PR TITLE
Publish Slooop 3.2.13 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,13 +5,13 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.12",
-			"code": 1092,
+			"name": "3.2.13",
+			"code": 1093,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 41351140,
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.12-1092/Dashchan_2-3.2.12-1092-ffmpeg8-all-abi-signed.apk",
+			"length": 41371926,
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.13-1093/Slooop-3.2.13-1093-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## Что изменено

- публичный манифест обновлений переключён на Slooop 3.2.13 (1093);
- указаны фактические URL, размер и существующий проверенный сертификат опубликованного APK;
- секция расширения Dvach не изменена.

## Проверки

- JSON успешно разобран;
- URL, размер и SHA-256 сопоставлены с единственным APK в GitHub Release;
- версия и fingerprint совпадают с независимо проверенным подписанным кандидатом.