### PR TITLE
Publish Slooop 3.2.14 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,13 +5,13 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.13",
-			"code": 1093,
+			"name": "3.2.14",
+			"code": 1094,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 41371926,
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.13-1093/Slooop-3.2.13-1093-ffmpeg8-all-abi-signed.apk",
+			"length": 41372079,
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.14-1094/Slooop-3.2.14-1094-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
Updates the stable in-app update manifest to Slooop 3.2.14 (version code 1094).

- References only the normal GitHub release APK.
- Keeps the verified release certificate fingerprint unchanged.
- Records the exact public APK length: `41372079` bytes.
- The public APK SHA-256 was verified as `22b0b275e7c2d10d618280db011262f17d6043de3cb43087603c3166eb63551d`.
- The separate F-Droid APK is intentionally not referenced by the in-app updater.

Checks performed:

- JSON parsing passed.
- Manifest version, code, URL, length, and certificate fingerprint match the published normal APK.
- The downloaded public asset matches the locally audited release candidate byte-for-byte.
