### PR TITLE
Publish Slooop 3.2.15 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,13 +5,13 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.14",
-			"code": 1094,
+			"name": "3.2.15",
+			"code": 1095,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 41372079,
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.14-1094/Slooop-3.2.14-1094-ffmpeg8-all-abi-signed.apk",
+			"length": 41372232,
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.15-1095/Slooop-3.2.15-1095-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## Summary
- point the stable in-app updater to the published Slooop 3.2.15 (1095) APK
- record the verified public asset length, URL and established signing fingerprint

## Verification
- public asset SHA-256: `d267440dfaf80b48e67072f5a08b1c9a92191d0a2e574118b0faba4552edb8c5`
- public asset size: `41372232` bytes
- downloaded release asset matches the protected signed candidate byte-for-byte

This PR changes only `update/data.json`; Android CI should use the manifest-only fast path.