### PR TITLE
Publish Slooop 3.2.17 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,13 +5,13 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.15",
-			"code": 1095,
+			"name": "3.2.17",
+			"code": 10970,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 41372232,
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.15-1095/Slooop-3.2.15-1095-ffmpeg8-all-abi-signed.apk",
+			"length": 41372542,
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.17/Slooop-3.2.17-10970-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## Summary

- publish Slooop `3.2.17 (10970)` to the stable in-app update channel
- point the manifest at the single universal GitHub APK
- record the verified APK byte length and existing signing fingerprint

## Verified release asset

- APK: `Slooop-3.2.17-10970-ffmpeg8-all-abi-signed.apk`
- Bytes: `41372542`
- SHA-256: `68b59fe90d0ea5c88a42855288606703bc52e45402b0a10978c3836cc907e7a2`
- Certificate SHA-256: `a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba`

This is a manifest-only change; no APK rebuild is required.
