### PR TITLE
Fix beta version gate parsing

### DIFF
--- a/.github/workflows/android-signed-candidate.yml
+++ b/.github/workflows/android-signed-candidate.yml
@@ -207,7 +207,7 @@ jobs:
                 *) echo "::error::Beta candidate version name is not marked beta: $release_version_name"; exit 1 ;;
               esac
               master_version_code="$(git show refs/remotes/origin/master:build.gradle | python3 -c \
-                'import re,sys; m=re.findall(r"^\\s*versionCode\\s*=\\s*(\\d+)\\s*$", sys.stdin.read(), re.M); print(m[0]) if len(m) == 1 else sys.exit(1)')"
+                'import re,sys; m=re.findall(r"^\s*versionCode\s*=\s*(\d+)\s*$", sys.stdin.read(), re.M); print(m[0]) if len(m) == 1 else sys.exit(1)')"
               if [ "$release_version_code" -le $((master_version_code + 3)) ]; then
                 echo "::error::Beta versionCode must exceed stable and reserved ABI codes: $release_version_code"
                 exit 1


### PR DESCRIPTION
## Root cause

The beta signed-candidate run stopped before Gradle because the inline Python regular expression contained double-escaped whitespace and digit classes. It therefore failed to read the stable `versionCode` under `set -e`.

## Fix

- use the intended Python regular expression escapes
- keep all candidate source, version, signing, and ABI checks unchanged

## Validation

- parsed `master` as `10970`
- parsed `beta` as `10974`
- confirmed the reserved version-code gate passes
- parsed the workflow YAML
- all workflow shell blocks passed `bash -n`
- `git diff --check` passed
