### PR TITLE
Publish Slooop 3.2.18 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,13 +5,13 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.17",
-			"code": 10970,
+			"name": "3.2.18",
+			"code": 10980,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 41372542,
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.17/Slooop-3.2.17-10970-ffmpeg8-all-abi-signed.apk",
+			"length": 43249197,
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.18/Slooop-3.2.18-10980-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## What changed

- Updated the stable client entry in `update/data.json` to Slooop 3.2.18 (10980).
- Set the published universal APK length to `43249197` bytes.
- Pointed the manifest to the final GitHub Release asset for tag `3.2.18`.
- Kept the existing release signing fingerprint unchanged.

## Published artifact

- APK: `Slooop-3.2.18-10980-ffmpeg8-all-abi-signed.apk`
- SHA-256: `2e04874d000bbc5d02a4146acbaa97c4a7d6e78ef8687c37dbe7d938760b8cac`
- Certificate SHA-256: `a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba`
- ABI: `arm64-v8a`, `armeabi-v7a`, `x86`

## Validation

- Parsed `update/data.json` successfully.
- Confirmed this commit changes only `update/data.json`.
- Confirmed the public asset URL resolves successfully.
- Confirmed version, length, URL and fingerprint match the independently verified signed artifact.
- Beta update metadata is not part of this change.