### PR TITLE
Publish Slooop 3.2.19 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,13 +5,13 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.18",
-			"code": 10980,
+			"name": "3.2.19",
+			"code": 10990,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 43249197,
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.18/Slooop-3.2.18-10980-ffmpeg8-all-abi-signed.apk",
+			"length": 43298349,
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.19/Slooop-3.2.19-10990-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## What changed

Updates the stable in-app update manifest to Slooop 3.2.19 (10990) using the exact published GitHub Release asset URL, byte length and existing release-signing fingerprint.

## Validation

- published Release contains exactly one universal signed APK;
- APK SHA-256: `9867859c0dcc88f3ba1b25b6222a2574b364a2fddefcb55ffb91c4135d7dbfe8`;
- APK length: `43298349` bytes;
- certificate SHA-256: `a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba`;
- JSON structure and exact asset values validated locally;
- beta metadata and F-Droid files are unchanged.