### PR TITLE
Disable beta updates in F-Droid builds

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -195,6 +195,42 @@ jobs:
           ./gradlew --no-daemon --stacktrace "$BUILD_TASK" "${gradle_args[@]}" \
             2>&1 | tee build-main.log
 
+      - name: Verify update-channel distribution boundary
+        if: steps.validation.outputs.build_required == 'true'
+        run: |
+          set -euo pipefail
+          marker='andrewpozdnakov7-jpg/Dashchan_2_Update_Test'
+          mapfile -d '' apks < <(find build/outputs/apk -type f -name '*.apk' -print0 | sort -z)
+          if [ "${#apks[@]}" -eq 0 ]; then
+            echo 'No APK files were produced' >&2
+            exit 1
+          fi
+          scan_root="$(mktemp -d)"
+          trap 'rm -rf "$scan_root"' EXIT
+          beta_reference_found=false
+          for index in "${!apks[@]}"; do
+            apk="${apks[$index]}"
+            unpacked="$scan_root/$index"
+            mkdir -p "$unpacked"
+            unzip -qq "$apk" -d "$unpacked"
+            if grep -aR -F -q "$marker" "$unpacked"; then
+              beta_reference_found=true
+              echo "Beta update reference found in $apk"
+            fi
+          done
+          if [ "$BUILD_TASK" = 'assembleFdroidRelease' ]; then
+            if [ "$beta_reference_found" = true ]; then
+              echo '::error::F-Droid APK contains the GitHub beta update repository reference'
+              exit 1
+            fi
+            echo 'F-Droid APK contains no GitHub beta update repository reference'
+          elif [ "$beta_reference_found" != true ]; then
+            echo '::error::GitHub APK lost its configured beta update repository reference'
+            exit 1
+          else
+            echo 'GitHub APK retains its configured beta update repository reference'
+          fi
+
       - name: Create APK checksums
         if: steps.validation.outputs.build_required == 'true'
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -281,9 +281,6 @@ android {
 				'andrewpozdnakov7-jpg/Dashchan_2/master/update/themes.json"'
 		buildConfigField 'String', 'GITHUB_URI_METADATA', '"//github.com/andrewpozdnakov7-jpg/Dashchan_2"'
 		buildConfigField 'String', 'GITHUB_PATH_METADATA', '"metadata"'
-		buildConfigField 'String', 'GITHUB_URI_METADATA_BETA',
-				'"//github.com/andrewpozdnakov7-jpg/Dashchan_2_Update_Test"'
-		buildConfigField 'String', 'GITHUB_PATH_METADATA_BETA', '"metadata"'
 		buildConfigField 'String', 'FILE_PROVIDER_AUTHORITY', '"' +
 				manifestPlaceholders.fileProviderAuthority + '"'
 		buildConfigField 'String', 'CHAN_EXTENSION_FEATURE_NAME', '"chan.extension"'
@@ -305,7 +302,11 @@ android {
 			buildConfigField 'boolean', 'ENABLE_LOCAL_TRANSLATION', 'true'
 			buildConfigField 'boolean', 'ALLOW_GMS_SECURITY_PROVIDER', 'true'
 			buildConfigField 'boolean', 'ALLOW_APPLICATION_SELF_UPDATE', 'true'
+			buildConfigField 'boolean', 'ALLOW_BETA_UPDATE_CHANNEL', 'true'
 			buildConfigField 'boolean', 'REQUIRE_EXTENSION_INSTALL_CONSENT', 'false'
+			buildConfigField 'String', 'GITHUB_URI_METADATA_BETA',
+					'"//github.com/andrewpozdnakov7-jpg/Dashchan_2_Update_Test"'
+			buildConfigField 'String', 'GITHUB_PATH_METADATA_BETA', '"metadata"'
 			buildConfigField 'String', 'URI_UPDATES', '"//raw.githubusercontent.com/' +
 					'andrewpozdnakov7-jpg/Dashchan_2/master/update/data.json"'
 			buildConfigField 'String', 'URI_UPDATES_BETA', '"//raw.githubusercontent.com/' +
@@ -324,7 +325,10 @@ android {
 			buildConfigField 'boolean', 'ENABLE_LOCAL_TRANSLATION', 'false'
 			buildConfigField 'boolean', 'ALLOW_GMS_SECURITY_PROVIDER', 'false'
 			buildConfigField 'boolean', 'ALLOW_APPLICATION_SELF_UPDATE', 'false'
+			buildConfigField 'boolean', 'ALLOW_BETA_UPDATE_CHANNEL', 'false'
 			buildConfigField 'boolean', 'REQUIRE_EXTENSION_INSTALL_CONSENT', 'true'
+			buildConfigField 'String', 'GITHUB_URI_METADATA_BETA', '""'
+			buildConfigField 'String', 'GITHUB_PATH_METADATA_BETA', '""'
 			buildConfigField 'String', 'URI_UPDATES', '""'
 			buildConfigField 'String', 'URI_UPDATES_BETA', '""'
 			buildConfigField 'String', 'UPDATE_MANIFEST_URL', '""'

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -652,6 +652,9 @@ public class Preferences {
 	public static final UpdateChannel DEFAULT_UPDATE_CHANNEL = UpdateChannel.STABLE;
 
 	public static UpdateChannel getUpdateChannel() {
+		if (!BuildConfig.ALLOW_BETA_UPDATE_CHANNEL) {
+			return UpdateChannel.STABLE;
+		}
 		String value = PREFERENCES.getString(KEY_UPDATE_CHANNEL, DEFAULT_UPDATE_CHANNEL.value);
 		for (UpdateChannel channel : UpdateChannel.values()) {
 			if (channel.value.equals(value)) {

--- a/src/com/mishiranu/dashchan/content/update/UpdateConfiguration.java
+++ b/src/com/mishiranu/dashchan/content/update/UpdateConfiguration.java
@@ -8,7 +8,8 @@ public final class UpdateConfiguration {
 	private UpdateConfiguration() {}
 
 	public static boolean isBetaChannel() {
-		return Preferences.getUpdateChannel() == Preferences.UpdateChannel.BETA;
+		return BuildConfig.ALLOW_BETA_UPDATE_CHANNEL &&
+				Preferences.getUpdateChannel() == Preferences.UpdateChannel.BETA;
 	}
 
 	public static String getLegacyManifestUrl() {
@@ -30,11 +31,11 @@ public final class UpdateConfiguration {
 	}
 
 	public static String getBetaMetadataUri() {
-		return BuildConfig.GITHUB_URI_METADATA_BETA;
+		return BuildConfig.ALLOW_BETA_UPDATE_CHANNEL ? BuildConfig.GITHUB_URI_METADATA_BETA : "";
 	}
 
 	public static String getBetaMetadataPath() {
-		return BuildConfig.GITHUB_PATH_METADATA_BETA;
+		return BuildConfig.ALLOW_BETA_UPDATE_CHANNEL ? BuildConfig.GITHUB_PATH_METADATA_BETA : "";
 	}
 
 	public static Uri resolveExtensionUpdateUri(Uri updateUri) {

--- a/src/com/mishiranu/dashchan/ui/preference/AboutFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/AboutFragment.java
@@ -62,31 +62,33 @@ public class AboutFragment extends PreferenceFragment implements FragmentHandler
 				.setOnClickListener(p -> ((FragmentHandler) requireActivity())
 						.pushFragment(new TextFragment(TextFragment.Type.CHANGELOG)));
 		if (BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
-			ListPreference updateChannelPreference = addList(Preferences.KEY_UPDATE_CHANNEL,
-					enumList(Preferences.UpdateChannel.values(), channel -> channel.value),
-					Preferences.DEFAULT_UPDATE_CHANNEL.value, R.string.update_channel,
-					enumResList(Preferences.UpdateChannel.values(), channel -> channel.titleResId));
-			updateChannelPreference.setOnBeforeChangeListener((preference, value) -> {
-				if (!confirmingBetaChannel && Preferences.UpdateChannel.BETA.value.equals(value) &&
-						!Preferences.UpdateChannel.BETA.value.equals(preference.getValue())) {
-					new AlertDialog.Builder(requireContext())
-							.setTitle(R.string.update_channel_beta)
-							.setMessage(R.string.beta_update_channel_warning__sentence)
-							.setNegativeButton(android.R.string.cancel, null)
-							.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-								confirmingBetaChannel = true;
-								preference.setValue(value);
-								confirmingBetaChannel = false;
-							})
-							.show();
-					return false;
-				}
-				return true;
-			});
-			updateChannelPreference.setOnAfterChangeListener(preference -> {
-				Preferences.resetUpdatePromptState();
-				((FragmentHandler) requireActivity()).pushFragment(new UpdateFragment());
-			});
+			if (BuildConfig.ALLOW_BETA_UPDATE_CHANNEL) {
+				ListPreference updateChannelPreference = addList(Preferences.KEY_UPDATE_CHANNEL,
+						enumList(Preferences.UpdateChannel.values(), channel -> channel.value),
+						Preferences.DEFAULT_UPDATE_CHANNEL.value, R.string.update_channel,
+						enumResList(Preferences.UpdateChannel.values(), channel -> channel.titleResId));
+				updateChannelPreference.setOnBeforeChangeListener((preference, value) -> {
+					if (!confirmingBetaChannel && Preferences.UpdateChannel.BETA.value.equals(value) &&
+							!Preferences.UpdateChannel.BETA.value.equals(preference.getValue())) {
+						new AlertDialog.Builder(requireContext())
+								.setTitle(R.string.update_channel_beta)
+								.setMessage(R.string.beta_update_channel_warning__sentence)
+								.setNegativeButton(android.R.string.cancel, null)
+								.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+									confirmingBetaChannel = true;
+									preference.setValue(value);
+									confirmingBetaChannel = false;
+								})
+								.show();
+						return false;
+					}
+					return true;
+				});
+				updateChannelPreference.setOnAfterChangeListener(preference -> {
+					Preferences.resetUpdatePromptState();
+					((FragmentHandler) requireActivity()).pushFragment(new UpdateFragment());
+				});
+			}
 			CheckPreference automaticUpdateCheck = addCheck(false, Preferences.KEY_UPDATE_AUTO_CHECK_ENABLED,
 					Preferences.isUpdateAutoCheckEnabled(), R.string.automatic_update_check, 0);
 			automaticUpdateCheck.setOnAfterChangeListener(preference ->

--- a/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
+++ b/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
@@ -466,7 +466,9 @@ public final class SettingsSearchIndex {
 		add(context, entries, Screen.ABOUT, R.string.backup_data, R.string.backup_data__summary, null);
 		add(context, entries, Screen.ABOUT, R.string.changelog);
 		if (BuildConfig.ALLOW_APPLICATION_SELF_UPDATE) {
-			add(context, entries, Screen.ABOUT, R.string.update_channel, 0, Preferences.KEY_UPDATE_CHANNEL);
+			if (BuildConfig.ALLOW_BETA_UPDATE_CHANNEL) {
+				add(context, entries, Screen.ABOUT, R.string.update_channel, 0, Preferences.KEY_UPDATE_CHANNEL);
+			}
 			add(context, entries, Screen.ABOUT, R.string.automatic_update_check, 0,
 					Preferences.KEY_UPDATE_AUTO_CHECK_ENABLED);
 			add(context, entries, Screen.ABOUT, R.string.check_for_updates);


### PR DESCRIPTION
## What changed

- adds an explicit `ALLOW_BETA_UPDATE_CHANNEL` distribution capability;
- keeps beta update URLs and metadata only in the GitHub flavor;
- forces the F-Droid flavor to ignore a previously stored beta-channel preference;
- hides the channel selector whenever beta updates are unsupported;
- verifies in CI that F-Droid APKs contain no reference to the beta update repository while GitHub APKs retain it.

## Why

The F-Droid flavor already disabled application self-updates, but the beta changelog metadata endpoint was defined globally and a migrated `beta` preference could still select beta metadata. This change closes that residual path and makes the distribution boundary explicit and testable.

## Impact

GitHub builds keep their existing stable/beta behavior. F-Droid builds cannot select or contact the beta update channel and continue to receive application updates only through F-Droid.

## Validation

- clean worktree based on current `origin/master`;
- `git diff --check` passed;
- protected version and update-manifest files are unchanged;
- diff contains no captcha/no-captcha functionality, credentials, local paths, or private data;
- GitHub and F-Droid APK boundary checks run in Android CI.