### PR TITLE
Prepare Slooop 3.2.22 feeds, video and privacy improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,8 +244,8 @@ android {
 
 	defaultConfig {
 		applicationId = 'io.dashchan2'
-		versionCode = 11010
-		versionName = '3.2.21'
+		versionCode = 11020
+		versionName = '3.2.22'
 		def releaseVersionCode = versionCode
 		def packageVersionCodeProperty = project.findProperty('packageVersionCode')
 		if (packageVersionCodeProperty != null) {

--- a/jni/src/player/player_seek.c
+++ b/jni/src/player/player_seek.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #define SEEK_KEYFRAME_DISCOVERY_THRESHOLD_MS 3000
+#define SEEK_PRECISE_SCAN_MAX_DRIFT_MS 3000
 
 static int64_t getSeekTimestampUs(Player * player, int64_t position) {
 	AVRational msTimeBase = {1, 1000};
@@ -410,6 +411,8 @@ void playerSeekSetPosition(JNIEnv * env, Player * player, int64_t position) {
 			int64_t seekPosition = max64(position - step, 0);
 			int64_t maxPosition = max64(position - previousStep, 0);
 			seekFrame(player, seekPosition, AVSEEK_FLAG_BACKWARD | AVSEEK_FLAG_ANY, NULL, NULL);
+			int audioPassedMax = !HAS_STREAM(player, audio);
+			int videoPassedMax = !HAS_STREAM(player, video);
 			while (!isSeekCancelled(player)) {
 				if (av_read_frame(player->av.format, &packet) < 0) {
 					break;
@@ -425,15 +428,23 @@ void playerSeekSetPosition(JNIEnv * env, Player * player, int64_t position) {
 						AVRational timeBase = player->av.format->streams[packet.stream_index]->time_base;
 						int64_t timestamp = getTimestampPositionMs(player, packet.pts, timeBase);
 						if (timestamp > maxPosition) {
-							av_packet_unref(&packet);
-							break;
-						}
-						if (timestamp > *outPosition) {
+							if (packet.stream_index == player->av.audioStreamIndex) {
+								audioPassedMax = 1;
+							} else {
+								videoPassedMax = 1;
+							}
+						} else if (timestamp > *outPosition) {
 							*outPosition = timestamp;
 						}
 					}
 				}
 				av_packet_unref(&packet);
+				// Packets from different streams are interleaved but are not guaranteed
+				// to cross maxPosition in timestamp order. Stopping after the first one
+				// can leave the other stream at the demuxer's old indexed keyframe.
+				if (audioPassedMax && videoPassedMax) {
+					break;
+				}
 			}
 			if (seekPosition <= 0) {
 				break;
@@ -450,9 +461,17 @@ void playerSeekSetPosition(JNIEnv * env, Player * player, int64_t position) {
 		if (videoPosition == -1) {
 			videoPosition = position;
 		}
-		position = min64(audioPosition, videoPosition);
-		diagnosticsLog("player=%u seek_phase=precise_scan_finished resolved_ms=%" PRId64,
-				player->meta.diagnosticsId, (int64_t) position);
+		int64_t resolvedPosition = min64(audioPosition, videoPosition);
+		int rejected = requestedPosition - resolvedPosition > SEEK_PRECISE_SCAN_MAX_DRIFT_MS;
+		// A partial Matroska/WebM index may seek every probe to the same old cue.
+		// Never turn that stale packet timestamp into the playback target: final
+		// keyframe discovery can safely decode forward from the requested position.
+		position = rejected ? requestedPosition : resolvedPosition;
+		diagnosticsLog("player=%u seek_phase=precise_scan_finished target_ms=%" PRId64
+				" audio_ms=%" PRId64 " video_ms=%" PRId64
+				" resolved_ms=%" PRId64 " rejected=%d",
+				player->meta.diagnosticsId, requestedPosition, audioPosition, videoPosition,
+				(int64_t) position, rejected);
 	}
 
 	int seekStreamIndex;

--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -1000,4 +1000,29 @@
 	<string name="vote_like">Нравится</string>
 	<string name="vote_dislike">Не нравится</string>
 	<string name="vote_already_submitted">Вы уже голосовали</string>
+	<string name="combined_feeds">Мои ленты</string>
+	<string name="combined_feeds__summary">Объединяйте несколько досок Двача в собственные ленты</string>
+	<string name="configure_combined_feeds">Настроить ленты</string>
+	<string name="configure_combined_feeds__summary">Создание и изменение собственных лент</string>
+	<string name="configure_combined_feed">Настроить ленту</string>
+	<string name="add_combined_feed">Добавить ленту</string>
+	<string name="edit_combined_feed">Изменить ленту</string>
+	<string name="combined_feed_name">Название ленты</string>
+	<string name="combined_feed_name_required">Введите название ленты</string>
+	<string name="combined_feed_minimum_boards">Выберите не менее двух досок</string>
+	<string name="show_sticky_threads">Показывать закреплённые треды</string>
+	<string name="combined_feeds_empty">Лент пока нет</string>
+	<string name="combined_feeds_add__summary">Выберите две или больше досок Двача</string>
+	<string name="combined_feeds_limit">Достигнут лимит лент</string>
+	<string name="combined_feeds_boards_unavailable">Список досок Двача недоступен</string>
+	<string name="combined_feed_not_found">Лента удалена или недоступна</string>
+	<string name="combined_feed_partial_failure__format">Не удалось обновить %1$d из %2$d досок</string>
+	<string name="combined_feed_failed__format">ошибок: %d</string>
+	<string name="delete_combined_feed_confirmation">Удалить эту ленту?</string>
+	<plurals name="number_boards__format">
+		<item quantity="one">%d доска</item>
+		<item quantity="few">%d доски</item>
+		<item quantity="many">%d досок</item>
+		<item quantity="other">%d доски</item>
+	</plurals>
 </resources>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -975,4 +975,27 @@
 	<string name="vote_like">Like</string>
 	<string name="vote_dislike">Dislike</string>
 	<string name="vote_already_submitted">You have already voted</string>
+	<string name="combined_feeds">My feeds</string>
+	<string name="combined_feeds__summary">Combine several Dvach boards into your own feeds</string>
+	<string name="configure_combined_feeds">Manage feeds</string>
+	<string name="configure_combined_feeds__summary">Create and edit your feeds</string>
+	<string name="configure_combined_feed">Configure feed</string>
+	<string name="add_combined_feed">Add feed</string>
+	<string name="edit_combined_feed">Edit feed</string>
+	<string name="combined_feed_name">Feed name</string>
+	<string name="combined_feed_name_required">Enter a feed name</string>
+	<string name="combined_feed_minimum_boards">Select at least two boards</string>
+	<string name="show_sticky_threads">Show sticky threads</string>
+	<string name="combined_feeds_empty">No feeds yet</string>
+	<string name="combined_feeds_add__summary">Select two or more Dvach boards</string>
+	<string name="combined_feeds_limit">Feed limit reached</string>
+	<string name="combined_feeds_boards_unavailable">Dvach board list is unavailable</string>
+	<string name="combined_feed_not_found">Feed was deleted or is unavailable</string>
+	<string name="combined_feed_partial_failure__format">Failed to update %1$d of %2$d boards</string>
+	<string name="combined_feed_failed__format">errors: %d</string>
+	<string name="delete_combined_feed_confirmation">Delete this feed?</string>
+	<plurals name="number_boards__format">
+		<item quantity="one">%d board</item>
+		<item quantity="other">%d boards</item>
+	</plurals>
 </resources>

--- a/metadata/versions.json
+++ b/metadata/versions.json
@@ -341,6 +341,12 @@
 			"name": "3.2.21",
 			"date": "07.08.2026",
 			"changelog": true
+		},
+		{
+			"code": 11020,
+			"name": "3.2.22",
+			"date": "11.08.2026",
+			"changelog": true
 		}
 	]
 }

--- a/res/values/ids.xml
+++ b/res/values/ids.xml
@@ -16,6 +16,7 @@
 	<item type="id" name="menu_clear_deleted" />
 	<item type="id" name="menu_clear_old" />
 	<item type="id" name="menu_contents" />
+	<item type="id" name="menu_configure_feed" />
 	<item type="id" name="menu_copy_link" />
 	<item type="id" name="menu_copy_text" />
 	<item type="id" name="menu_date_created" />

--- a/src/chan/http/HttpClient.java
+++ b/src/chan/http/HttpClient.java
@@ -411,7 +411,7 @@ public class HttpClient {
 					}
 					connection.setRequestProperty(header.first, header.second);
 					if ("User-Agent".equalsIgnoreCase(header.first)) {
-						userAgent = header.first;
+						userAgent = header.second;
 						userAgentSet = true;
 					}
 					if ("Accept-Encoding".equalsIgnoreCase(header.first)) {

--- a/src/com/mishiranu/dashchan/content/BackupManager.java
+++ b/src/com/mishiranu/dashchan/content/BackupManager.java
@@ -7,6 +7,7 @@ import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.content.database.CommonDatabase;
 import com.mishiranu.dashchan.content.service.DownloadService;
 import com.mishiranu.dashchan.content.storage.AutohideStorage;
+import com.mishiranu.dashchan.content.storage.CombinedFeedStorage;
 import com.mishiranu.dashchan.content.storage.FavoritesStorage;
 import com.mishiranu.dashchan.content.storage.StatisticsStorage;
 import com.mishiranu.dashchan.content.storage.ThemesStorage;
@@ -134,6 +135,8 @@ public class BackupManager {
 				Arrays.asList(BACKUP_VERSION_0, BACKUP_VERSION_1)),
 		AUTOHIDE(R.string.autohide, AutohideStorage.getInstance().getFilesForBackup(),
 				Arrays.asList(BACKUP_VERSION_0, BACKUP_VERSION_1)),
+		COMBINED_FEEDS(R.string.combined_feeds, CombinedFeedStorage.getInstance().getFilesForBackup(),
+				Collections.singletonList(BACKUP_VERSION_1)),
 		STATISTICS(R.string.statistics, StatisticsStorage.getInstance().getFilesForBackup(),
 				Arrays.asList(BACKUP_VERSION_0, BACKUP_VERSION_1)),
 		THEMES(R.string.themes, ThemesStorage.getInstance().getFilesForBackup(),

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -1788,6 +1788,8 @@ public class Preferences {
 	public static final boolean DEFAULT_IMAGE_EDITOR = true;
 	public static final String KEY_OPEN_CONFIGURED_ATTACHMENT_FOLDER = "open_configured_attachment_folder";
 	public static final boolean DEFAULT_OPEN_CONFIGURED_ATTACHMENT_FOLDER = false;
+	public static final String KEY_COMBINED_FEEDS_ENABLED = "combined_feeds_enabled";
+	public static final boolean DEFAULT_COMBINED_FEEDS_ENABLED = true;
 	public static final String KEY_LOCAL_TRANSLATION = "local_translation";
 	public static final boolean DEFAULT_LOCAL_TRANSLATION = false;
 	public static final String KEY_TRANSLATION_NATIVE_LANGUAGE = "translation_native_language";
@@ -1814,6 +1816,10 @@ public class Preferences {
 	public static boolean isOpenConfiguredAttachmentFolderEnabled() {
 		return PREFERENCES.getBoolean(KEY_OPEN_CONFIGURED_ATTACHMENT_FOLDER,
 				DEFAULT_OPEN_CONFIGURED_ATTACHMENT_FOLDER);
+	}
+
+	public static boolean isCombinedFeedsEnabled() {
+		return PREFERENCES.getBoolean(KEY_COMBINED_FEEDS_ENABLED, DEFAULT_COMBINED_FEEDS_ENABLED);
 	}
 
 	public static boolean isLocalTranslationEnabled() {

--- a/src/com/mishiranu/dashchan/content/model/PostItem.java
+++ b/src/com/mishiranu/dashchan/content/model/PostItem.java
@@ -80,6 +80,7 @@ public class PostItem implements AttachmentItem.Master, ChanMarkup.MarkupExtra, 
 
 	private final Post post;
 	private final ThreadData threadData;
+	private final String chanName;
 	private final String boardName;
 	private final String threadNumber;
 	private final PostNumber originalPostNumber;
@@ -160,6 +161,7 @@ public class PostItem implements AttachmentItem.Master, ChanMarkup.MarkupExtra, 
 	private PostItem(Post post, ThreadData.Base threadDataBase, Chan chan,
 			String boardName, String threadNumber, PostNumber originalPostNumber) {
 		this.post = post;
+		this.chanName = chan.name;
 		this.boardName = boardName;
 		this.threadNumber = threadNumber;
 		this.originalPostNumber = originalPostNumber;
@@ -297,6 +299,10 @@ public class PostItem implements AttachmentItem.Master, ChanMarkup.MarkupExtra, 
 	@Override
 	public String getBoardName() {
 		return boardName;
+	}
+
+	public String getChanName() {
+		return chanName;
 	}
 
 	@Override
@@ -798,6 +804,16 @@ public class PostItem implements AttachmentItem.Master, ChanMarkup.MarkupExtra, 
 	@Override
 	public long getTimestamp() {
 		return post.timestamp;
+	}
+
+	public long getThreadLatestTimestamp() {
+		long timestamp = post.timestamp;
+		if (threadData != null && threadData.base.posts != null) {
+			for (Post threadPost : threadData.base.posts) {
+				timestamp = Math.max(timestamp, threadPost.timestamp);
+			}
+		}
+		return timestamp;
 	}
 
 	public String getDateTime(PostDateFormatter formatter) {

--- a/src/com/mishiranu/dashchan/content/net/UserAgentProvider.java
+++ b/src/com/mishiranu/dashchan/content/net/UserAgentProvider.java
@@ -3,17 +3,21 @@ package com.mishiranu.dashchan.content.net;
 import android.app.Application;
 import android.webkit.WebSettings;
 
-import chan.util.StringUtils;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class UserAgentProvider {
 	private static final UserAgentProvider INSTANCE = new UserAgentProvider();
+	private static final Pattern CHROMIUM_MAJOR_PATTERN = Pattern.compile("(?:Chrome|Chromium)/([0-9]{1,6})",
+			Pattern.CASE_INSENSITIVE);
+	private static final int FALLBACK_CHROMIUM_MAJOR = 100;
+	private static final String USER_AGENT_FORMAT = "Mozilla/5.0 (Linux; Android 10; K; wv) " +
+			"AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/%d.0.0.0 Mobile Safari/537.36";
 
 	public static void initialize(Application application) {
 		try {
-			String userAgent = WebSettings.getDefaultUserAgent(application);
-			if (!StringUtils.isEmpty(userAgent)) {
-				INSTANCE.userAgent = userAgent;
-			}
+			INSTANCE.userAgent = sanitizeUserAgent(WebSettings.getDefaultUserAgent(application));
 		} catch (RuntimeException e) {
 			e.printStackTrace();
 		}
@@ -23,9 +27,31 @@ public class UserAgentProvider {
 		return INSTANCE;
 	}
 
-	private String userAgent = "Mozilla/5.0";
+	private String userAgent = formatUserAgent(FALLBACK_CHROMIUM_MAJOR);
 
 	private UserAgentProvider() {}
+
+	static String sanitizeUserAgent(String source) {
+		int chromiumMajor = FALLBACK_CHROMIUM_MAJOR;
+		if (source != null) {
+			Matcher matcher = CHROMIUM_MAJOR_PATTERN.matcher(source);
+			if (matcher.find()) {
+				try {
+					int parsed = Integer.parseInt(matcher.group(1));
+					if (parsed > 0) {
+						chromiumMajor = parsed;
+					}
+				} catch (NumberFormatException e) {
+					// Use the privacy-safe fallback.
+				}
+			}
+		}
+		return formatUserAgent(chromiumMajor);
+	}
+
+	private static String formatUserAgent(int chromiumMajor) {
+		return String.format(Locale.US, USER_AGENT_FORMAT, chromiumMajor);
+	}
 
 	public String getUserAgent() {
 		return userAgent;

--- a/src/com/mishiranu/dashchan/content/storage/CombinedFeedStorage.java
+++ b/src/com/mishiranu/dashchan/content/storage/CombinedFeedStorage.java
@@ -1,0 +1,215 @@
+package com.mishiranu.dashchan.content.storage;
+
+import chan.util.StringUtils;
+import com.mishiranu.dashchan.util.WeakObservable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class CombinedFeedStorage extends StorageManager.JsonOrgStorage<List<CombinedFeedStorage.Feed>> {
+	private static final String KEY_FEEDS = "feeds";
+	public static final int MAX_FEEDS = 20;
+
+	public interface Observer {
+		void onCombinedFeedsChanged();
+	}
+
+	public static class Source {
+		public String chanName;
+		public String boardName;
+
+		public Source() {}
+
+		public Source(String chanName, String boardName) {
+			this.chanName = chanName;
+			this.boardName = boardName;
+		}
+
+		public Source(Source source) {
+			this(source.chanName, source.boardName);
+		}
+
+		private JSONObject serialize() throws JSONException {
+			return new JSONObject().put("chanName", chanName).put("boardName", boardName);
+		}
+
+		private static Source deserialize(JSONObject json) {
+			return new Source(json.optString("chanName"), json.optString("boardName"));
+		}
+	}
+
+	public static class Feed {
+		public String id;
+		public String title;
+		public boolean showSticky = true;
+		public final ArrayList<Source> sources = new ArrayList<>();
+
+		public Feed() {}
+
+		public Feed(Feed feed) {
+			id = feed.id;
+			title = feed.title;
+			showSticky = feed.showSticky;
+			for (Source source : feed.sources) {
+				sources.add(new Source(source));
+			}
+		}
+
+		public String getPrimaryChanName() {
+			return sources.isEmpty() ? null : sources.get(0).chanName;
+		}
+
+		public boolean containsChan(String chanName) {
+			for (Source source : sources) {
+				if (source.chanName.equals(chanName)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private JSONObject serialize() throws JSONException {
+			JSONArray array = new JSONArray();
+			for (Source source : sources) {
+				array.put(source.serialize());
+			}
+			return new JSONObject().put("id", id).put("title", title)
+					.put("showSticky", showSticky).put("sources", array);
+		}
+
+		private static Feed deserialize(JSONObject json) {
+			Feed feed = new Feed();
+			feed.id = json.optString("id");
+			feed.title = json.optString("title");
+			feed.showSticky = json.optBoolean("showSticky", true);
+			JSONArray array = json.optJSONArray("sources");
+			if (array != null) {
+				for (int i = 0; i < array.length(); i++) {
+					JSONObject sourceJson = array.optJSONObject(i);
+					if (sourceJson != null) {
+						Source source = Source.deserialize(sourceJson);
+						if (!StringUtils.isEmpty(source.chanName) && !StringUtils.isEmpty(source.boardName)) {
+							feed.sources.add(source);
+						}
+					}
+				}
+			}
+			return feed;
+		}
+	}
+
+	private static final CombinedFeedStorage INSTANCE = new CombinedFeedStorage();
+
+	public static CombinedFeedStorage getInstance() {
+		return INSTANCE;
+	}
+
+	private final LinkedHashMap<String, Feed> feeds = new LinkedHashMap<>();
+	private final WeakObservable<Observer> observable = new WeakObservable<>();
+
+	private CombinedFeedStorage() {
+		super("combined_feeds", 500, 5000);
+		startRead();
+	}
+
+	public WeakObservable<Observer> getObservable() {
+		return observable;
+	}
+
+	@Override
+	public synchronized List<Feed> onClone() {
+		ArrayList<Feed> result = new ArrayList<>(feeds.size());
+		for (Feed feed : feeds.values()) {
+			result.add(new Feed(feed));
+		}
+		return result;
+	}
+
+	@Override
+	public synchronized void onDeserialize(JSONObject jsonObject) {
+		JSONArray array = jsonObject.optJSONArray(KEY_FEEDS);
+		if (array == null) {
+			return;
+		}
+		for (int i = 0; i < array.length() && feeds.size() < MAX_FEEDS; i++) {
+			JSONObject json = array.optJSONObject(i);
+			if (json != null) {
+				Feed feed = Feed.deserialize(json);
+				if (!StringUtils.isEmpty(feed.id) && isValid(feed)) {
+					feeds.put(feed.id, feed);
+				}
+			}
+		}
+	}
+
+	@Override
+	public JSONObject onSerialize(List<Feed> feeds) throws JSONException {
+		JSONArray array = new JSONArray();
+		for (Feed feed : feeds) {
+			array.put(feed.serialize());
+		}
+		return new JSONObject().put(KEY_FEEDS, array);
+	}
+
+	public synchronized List<Feed> getFeeds() {
+		return onClone();
+	}
+
+	public synchronized Feed getFeed(String id) {
+		Feed feed = feeds.get(id);
+		return feed != null ? new Feed(feed) : null;
+	}
+
+	public synchronized boolean put(Feed feed) {
+		if (!isValid(feed)) {
+			return false;
+		}
+		if (StringUtils.isEmpty(feed.id)) {
+			if (feeds.size() >= MAX_FEEDS) {
+				return false;
+			}
+			feed.id = UUID.randomUUID().toString();
+		} else if (!feeds.containsKey(feed.id) && feeds.size() >= MAX_FEEDS) {
+			return false;
+		}
+		feeds.put(feed.id, new Feed(feed));
+		serialize();
+		notifyChanged();
+		return true;
+	}
+
+	private static boolean isValid(Feed feed) {
+		if (StringUtils.isEmptyOrWhitespace(feed.title) || feed.sources.size() < 2) {
+			return false;
+		}
+		ArrayList<String> sourceKeys = new ArrayList<>();
+		for (Source source : feed.sources) {
+			if (StringUtils.isEmpty(source.chanName) || StringUtils.isEmpty(source.boardName)) {
+				return false;
+			}
+			String key = source.chanName + '\n' + source.boardName;
+			if (sourceKeys.contains(key)) {
+				return false;
+			}
+			sourceKeys.add(key);
+		}
+		return true;
+	}
+
+	public synchronized void remove(String id) {
+		if (feeds.remove(id) != null) {
+			serialize();
+			notifyChanged();
+		}
+	}
+
+	private void notifyChanged() {
+		for (Observer observer : observable) {
+			observer.onCombinedFeedsChanged();
+		}
+	}
+}

--- a/src/com/mishiranu/dashchan/ui/DrawerForm.java
+++ b/src/com/mishiranu/dashchan/ui/DrawerForm.java
@@ -47,6 +47,7 @@ import com.mishiranu.dashchan.R;
 import com.mishiranu.dashchan.content.Preferences;
 import com.mishiranu.dashchan.content.model.PostNumber;
 import com.mishiranu.dashchan.content.service.WatcherService;
+import com.mishiranu.dashchan.content.storage.CombinedFeedStorage;
 import com.mishiranu.dashchan.content.storage.FavoritesStorage;
 import com.mishiranu.dashchan.graphics.ChanIconDrawable;
 import com.mishiranu.dashchan.util.FlagUtils;
@@ -65,6 +66,7 @@ import com.mishiranu.dashchan.widget.SortableHelper;
 import com.mishiranu.dashchan.widget.ThemeEngine;
 import com.mishiranu.dashchan.widget.WatcherView;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -105,9 +107,12 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	private static final int PREWARM_ITEM_COUNT = 12;
 	private boolean drawerPrewarmScheduled;
 	private boolean drawerPrewarmed;
+	private int[] drawerPrewarmViewTypes;
+	private int drawerPrewarmViewTypeIndex;
 
 	private boolean mergeChans = false;
 	private boolean showHistory = false;
+	private boolean combinedFeedsEnabled = false;
 	private Preferences.PagesListMode pagesListMode = null;
 	private boolean chanSelectMode = false;
 	private boolean showRestartButton = false;
@@ -155,6 +160,7 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	public interface Callback {
 		void onSelectChan(String chanName);
 		void onSelectBoard(String chanName, String boardName, boolean fromCache);
+		void onSelectCombinedFeed(String feedId);
 		boolean onSelectThread(String chanName, String boardName, String threadNumber, PostNumber postNumber,
 				String threadTitle, boolean fromCache);
 		void onClosePage(String chanName, String boardName, String threadNumber);
@@ -435,11 +441,13 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	private boolean updatePreferencesWithoutConfiguration() {
 		boolean mergeChans = Preferences.isMergeChans();
 		boolean showHistory = Preferences.isRememberHistory();
+		boolean combinedFeedsEnabled = Preferences.isCombinedFeedsEnabled();
 		Preferences.PagesListMode pagesListMode = Preferences.getPagesListMode();
 		if (this.mergeChans != mergeChans || this.showHistory != showHistory ||
-				this.pagesListMode != pagesListMode) {
+				this.combinedFeedsEnabled != combinedFeedsEnabled || this.pagesListMode != pagesListMode) {
 			this.mergeChans = mergeChans;
 			this.showHistory = showHistory;
+			this.combinedFeedsEnabled = combinedFeedsEnabled;
 			this.pagesListMode = pagesListMode;
 			return true;
 		}
@@ -461,6 +469,10 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 			return;
 		}
 		switch (listItem.type) {
+			case COMBINED_FEED: {
+				callback.onSelectCombinedFeed(listItem.boardName);
+				break;
+			}
 			case PAGE:
 			case FAVORITE: {
 				boolean fromCache = listItem.type == ListItem.Type.PAGE;
@@ -947,6 +959,22 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	private void updateListPages() {
 		this.pages.clear();
 		boolean mergeChans = this.mergeChans;
+		ArrayList<CombinedFeedStorage.Feed> combinedFeeds = new ArrayList<>();
+		if (combinedFeedsEnabled) {
+			for (CombinedFeedStorage.Feed feed : CombinedFeedStorage.getInstance().getFeeds()) {
+				if (mergeChans || feed.containsChan(chanName)) {
+					combinedFeeds.add(feed);
+				}
+			}
+		}
+		if (!combinedFeeds.isEmpty()) {
+			this.pages.add(new ListItem(ListItem.Type.SECTION, null, null, null,
+					context.getString(R.string.combined_feeds)));
+			for (CombinedFeedStorage.Feed feed : combinedFeeds) {
+				this.pages.add(new ListItem(ListItem.Type.COMBINED_FEED, feed.getPrimaryChanName(),
+						feed.id, null, feed.title));
+			}
+		}
 		Collection<Page> allPages = callback.obtainDrawerPages();
 		ArrayList<Page> pages = new ArrayList<>();
 		for (Page page : allPages) {
@@ -1054,7 +1082,7 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	}
 
 	private static class ListItem {
-		public enum Type {HEADER, RESTART, SECTION, PAGE, FAVORITE, MENU, CHAN}
+		public enum Type {HEADER, RESTART, SECTION, COMBINED_FEED, PAGE, FAVORITE, MENU, CHAN}
 
 		public static final ListItem HEADER = new ListItem(Type.HEADER, null, null, null, null);
 		public static final ListItem RESTART = new ListItem(Type.RESTART, null, null, null, null);
@@ -1093,6 +1121,7 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 				String chanName, String boardName, String threadNumber, String title) {
 			long hash = appendIdHash(ID_HASH_OFFSET, type.ordinal());
 			switch (type) {
+				case COMBINED_FEED:
 				case PAGE:
 				case FAVORITE: {
 					hash = appendIdHash(hash, chanName);
@@ -1401,6 +1430,10 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 						? ViewType.SECTION_BUTTON : ViewType.SECTION;
 				break;
 			}
+			case COMBINED_FEED: {
+				viewType = ViewType.ITEM;
+				break;
+			}
 			case PAGE: {
 				viewType = mergeChans ? ViewType.CLOSEABLE_ICON : ViewType.CLOSEABLE;
 				break;
@@ -1514,42 +1547,55 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 			return;
 		}
 		drawerPrewarmScheduled = true;
-		// RecyclerView otherwise creates every visible drawer row during the first opening animation.
-		Looper.myQueue().addIdleHandler(() -> {
-			drawerPrewarmScheduled = false;
-			if (!drawerOpened && !drawerAlwaysVisible && drawerState == DrawerLayout.STATE_IDLE && !drawerPrewarmed) {
-				prewarmDrawerHolders();
-			}
-			return false;
-		});
+		drawerPrewarmViewTypes = null;
+		drawerPrewarmViewTypeIndex = 0;
+		// RecyclerView otherwise creates every visible drawer row during the first opening animation. Create
+		// only one holder per idle opportunity so prewarming itself cannot become a long UI-thread stall.
+		Looper.myQueue().addIdleHandler(this::prewarmNextDrawerHolder);
 	}
 
-	private void prewarmDrawerHolders() {
-		Trace.beginSection("DrawerForm#prewarmHolders");
-		try {
+	private boolean prewarmNextDrawerHolder() {
+		if (drawerOpened || drawerAlwaysVisible || drawerState != DrawerLayout.STATE_IDLE || drawerPrewarmed) {
+			drawerPrewarmScheduled = false;
+			drawerPrewarmViewTypes = null;
+			return false;
+		}
+		if (drawerPrewarmViewTypes == null) {
 			int count = Math.min(getItemCount(), PREWARM_ITEM_COUNT);
+			int[] viewTypes = new int[count];
+			int viewTypesCount = 0;
 			int[] typeCounts = new int[ViewType.values().length];
 			for (int position = 0; position < count; position++) {
 				int viewType = getItemViewType(position);
 				ViewType type = ViewType.values()[viewType];
 				if (type != ViewType.HEADER && type != ViewType.RESTART) {
+					viewTypes[viewTypesCount++] = viewType;
 					typeCounts[viewType]++;
 				}
 			}
+			drawerPrewarmViewTypes = Arrays.copyOf(viewTypes, viewTypesCount);
 			RecyclerView.RecycledViewPool pool = recyclerView.getRecycledViewPool();
 			for (int viewType = 0; viewType < typeCounts.length; viewType++) {
-				int typeCount = typeCounts[viewType];
-				if (typeCount > 0) {
-					pool.setMaxRecycledViews(viewType, Math.max(5, typeCount));
-					for (int i = 0; i < typeCount; i++) {
-						pool.putRecycledView(createViewHolder(recyclerView, viewType));
-					}
+				if (typeCounts[viewType] > 0) {
+					pool.setMaxRecycledViews(viewType, Math.max(5, typeCounts[viewType]));
 				}
 			}
+		}
+		if (drawerPrewarmViewTypeIndex >= drawerPrewarmViewTypes.length) {
 			drawerPrewarmed = true;
+			drawerPrewarmScheduled = false;
+			drawerPrewarmViewTypes = null;
+			return false;
+		}
+		Trace.beginSection("DrawerForm#prewarmHolder");
+		try {
+			RecyclerView.RecycledViewPool pool = recyclerView.getRecycledViewPool();
+			int viewType = drawerPrewarmViewTypes[drawerPrewarmViewTypeIndex++];
+			pool.putRecycledView(createViewHolder(recyclerView, viewType));
 		} finally {
 			Trace.endSection();
 		}
+		return true;
 	}
 
 	private int prepareCategoriesArray() {
@@ -1796,10 +1842,12 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 				// Do nothing
 				break;
 			}
+			case COMBINED_FEED:
 			case PAGE:
 			case FAVORITE: {
-				holder.text.setText(formatBoardThreadTitle(listItem.isThreadItem(),
-						listItem.boardName, listItem.threadNumber, listItem.title));
+				holder.text.setText(listItem.type == ListItem.Type.COMBINED_FEED ? listItem.title
+						: formatBoardThreadTitle(listItem.isThreadItem(),
+								listItem.boardName, listItem.threadNumber, listItem.title));
 				if (listItem.type == ListItem.Type.FAVORITE && listItem.isThreadItem() &&
 						watcherSupportSet.contains(listItem.chanName)) {
 					holder.watcher.setProgressAnimationEnabled(canApplyWatcherUpdates());

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -60,6 +60,7 @@ import com.mishiranu.dashchan.content.service.DownloadService;
 import com.mishiranu.dashchan.content.service.PostingService;
 import com.mishiranu.dashchan.content.service.WatcherService;
 import com.mishiranu.dashchan.content.storage.FavoritesStorage;
+import com.mishiranu.dashchan.content.storage.CombinedFeedStorage;
 import com.mishiranu.dashchan.content.update.UpdateDialogHelper;
 import com.mishiranu.dashchan.ui.gallery.GalleryOverlay;
 import com.mishiranu.dashchan.ui.navigator.Page;
@@ -105,7 +106,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class MainActivity extends StateActivity implements DrawerForm.Callback, ThemeDialog.Callback,
-		FavoritesStorage.Observer, WatcherService.Client.Callback,
+		FavoritesStorage.Observer, CombinedFeedStorage.Observer, WatcherService.Client.Callback,
 		UiManager.Callback, UiManager.LocalNavigator, FragmentHandler, PageFragment.Callback {
 	private static final String EXTRA_FRAGMENTS = "fragments";
 	private static final String EXTRA_STACK_PAGE_ITEMS = "stackPageItems";
@@ -140,6 +141,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	private CustomDrawerLayout drawerLayout;
 	private DrawerToggle drawerToggle;
 	private Runnable pendingDrawerNavigation;
+	private boolean performingDrawerNavigation;
 	private final HashSet<String> navigationAreaLockers = new HashSet<>();
 
 	private ExpandedScreen expandedScreen;
@@ -183,6 +185,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		ClickableToast.register(this);
 		ForegroundManager.getInstance().register(this);
 		FavoritesStorage.getInstance().getObservable().register(this);
+		CombinedFeedStorage.getInstance().getObservable().register(this);
 		Preferences.PREFERENCES.register(preferencesListener);
 		ChanManager.getInstance().observable.register(chanManagerCallback);
 		watcherServiceClient = WatcherService.getClient(this);
@@ -372,7 +375,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				getSupportFragmentManager().beginTransaction()
 						.replace(R.id.content_fragment, currentFragmentFromSaved)
 						.commit();
-				updatePostFragmentConfiguration();
+				updatePostFragmentConfiguration(currentFragmentFromSaved);
 			}
 		} else {
 			ContentFragment currentFragment = getCurrentFragment();
@@ -382,7 +385,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				currentPageItem = null;
 			}
 			if (currentFragment != null) {
-				updatePostFragmentConfiguration();
+				updatePostFragmentConfiguration(currentFragment);
 			}
 		}
 
@@ -1128,6 +1131,11 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 						new ListPage.InitRequest(!fromCache, null, null));
 				break;
 			}
+			case COMBINED_THREADS: {
+				pair = prepareAddPage(content, chanName, boardName, null, null,
+						new ListPage.InitRequest(!fromCache, null, null));
+				break;
+			}
 			case POSTS: {
 				pair = prepareAddPage(content, chanName, boardName, threadNumber, null,
 						new ListPage.InitRequest(!fromCache, postNumber, threadTitle));
@@ -1204,11 +1212,12 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 			pageItem.createdRealtime = SystemClock.elapsedRealtime();
 		}
 		currentPageItem = pageItem;
-		fragmentManager.beginTransaction()
-				.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-				.replace(R.id.content_fragment, fragment)
-				.commit();
-		updatePostFragmentConfiguration();
+		FragmentTransaction transaction = fragmentManager.beginTransaction();
+		transaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
+		transaction.replace(R.id.content_fragment, fragment).commit();
+		// Don't call getCurrentFragment() here: it executes the pending transaction synchronously and used to
+		// inflate the destination screen in the same frame as drawer navigation.
+		updatePostFragmentConfiguration(fragment);
 
 		if (currentFragment instanceof PageFragment || fragment instanceof PageFragment) {
 			HashSet<String> retainIds = new HashSet<>(1 + stackPageItems.size() + preservedPageItems.size());
@@ -1240,11 +1249,13 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		}
 	}
 
-	private boolean deferNavigationUntilDrawerClosed(Runnable navigation) {
-		if (!wideMode && drawerLayout.isDrawerVisible(GravityCompat.START)) {
-			// Fragment creation can take several frames; don't run it concurrently with the drawer animation.
+	private boolean scheduleDrawerNavigation(Runnable navigation) {
+		if (!performingDrawerNavigation && !wideMode && drawerLayout.isDrawerVisible(GravityCompat.START)) {
+			// Start closing now, then navigate on the next frame. This keeps the drawer and fragment transitions
+			// visually concurrent without doing the navigation work in the click frame.
 			pendingDrawerNavigation = navigation;
 			drawerLayout.closeDrawer(GravityCompat.START);
+			drawerLayout.postOnAnimation(this::runPendingDrawerNavigation);
 			return true;
 		}
 		return false;
@@ -1254,19 +1265,22 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		Runnable navigation = pendingDrawerNavigation;
 		pendingDrawerNavigation = null;
 		if (navigation != null) {
-			drawerLayout.post(() -> {
-				Trace.beginSection("MainActivity#drawerNavigation");
-				try {
-					navigation.run();
-				} finally {
-					Trace.endSection();
-				}
-			});
+			Trace.beginSection("MainActivity#drawerNavigation");
+			performingDrawerNavigation = true;
+			try {
+				navigation.run();
+			} finally {
+				performingDrawerNavigation = false;
+				Trace.endSection();
+			}
 		}
 	}
 
 	private void updatePostFragmentConfiguration() {
-		ContentFragment currentFragment = getCurrentFragment();
+		updatePostFragmentConfiguration(getCurrentFragment());
+	}
+
+	private void updatePostFragmentConfiguration(ContentFragment currentFragment) {
 		String chanName;
 		if (currentFragment instanceof PageFragment) {
 			chanName = ((PageFragment) currentFragment).getPage().chanName;
@@ -1474,6 +1488,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		unbindService(downloadConnection);
 		watcherServiceClient.setCallback(null);
 		FavoritesStorage.getInstance().getObservable().unregister(this);
+		CombinedFeedStorage.getInstance().getObservable().unregister(this);
 		Preferences.PREFERENCES.unregister(preferencesListener);
 		ChanManager.getInstance().observable.unregister(chanManagerCallback);
 		for (Chan chan : ChanManager.getInstance().getAvailableChans()) {
@@ -1482,6 +1497,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 		notificationManager.cancel(C.NOTIFICATION_ID_UPDATES);
 		FavoritesStorage.getInstance().await(true);
+		CombinedFeedStorage.getInstance().await(true);
 	}
 
 	@Override
@@ -1861,7 +1877,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 
 	@Override
 	public void onSelectChan(String chanName) {
-		if (deferNavigationUntilDrawerClosed(() -> onSelectChan(chanName))) {
+		if (scheduleDrawerNavigation(() -> onSelectChan(chanName))) {
 			return;
 		}
 		ContentFragment currentFragment = getCurrentFragment();
@@ -1910,7 +1926,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	@Override
 	public void onSelectBoard(String chanName, String boardName, boolean fromCache) {
 		String requestedBoardName = boardName;
-		if (deferNavigationUntilDrawerClosed(() -> onSelectBoard(chanName, requestedBoardName, fromCache))) {
+		if (scheduleDrawerNavigation(() -> onSelectBoard(chanName, requestedBoardName, fromCache))) {
 			return;
 		}
 		ContentFragment currentFragment = getCurrentFragment();
@@ -1927,10 +1943,31 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	}
 
 	@Override
+	public void onSelectCombinedFeed(String feedId) {
+		if (scheduleDrawerNavigation(() -> onSelectCombinedFeed(feedId))) {
+			return;
+		}
+		CombinedFeedStorage.Feed feed = CombinedFeedStorage.getInstance().getFeed(feedId);
+		if (feed == null || feed.sources.size() < 2 || Chan.get(feed.getPrimaryChanName()).name == null) {
+			ClickableToast.show(R.string.combined_feed_not_found);
+			return;
+		}
+		navigatePage(Page.Content.COMBINED_THREADS, feed.getPrimaryChanName(), feed.id,
+				null, null, null, null, FLAG_PAGE_CLOSE_OVERLAYS | FLAG_PAGE_FROM_CACHE);
+	}
+
+	@Override
+	public void onCombinedFeedsChanged() {
+		if (drawerForm != null) {
+			drawerForm.updateItems(true, false);
+		}
+	}
+
+	@Override
 	public boolean onSelectThread(String chanName, String boardName, String threadNumber, PostNumber postNumber,
 			String threadTitle, boolean fromCache) {
 		String requestedBoardName = boardName;
-		if (deferNavigationUntilDrawerClosed(() -> onSelectThread(chanName, requestedBoardName, threadNumber,
+		if (scheduleDrawerNavigation(() -> onSelectThread(chanName, requestedBoardName, threadNumber,
 				postNumber, threadTitle, fromCache))) {
 			return true;
 		}
@@ -2084,7 +2121,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 
 	@Override
 	public void onSelectDrawerMenuItem(int item) {
-		if (deferNavigationUntilDrawerClosed(() -> onSelectDrawerMenuItem(item))) {
+		if (scheduleDrawerNavigation(() -> onSelectDrawerMenuItem(item))) {
 			return;
 		}
 		Page.Content content = null;

--- a/src/com/mishiranu/dashchan/ui/navigator/Page.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/Page.java
@@ -7,6 +7,7 @@ import chan.util.CommonUtils;
 import com.mishiranu.dashchan.content.Preferences;
 import com.mishiranu.dashchan.ui.navigator.page.ArchivePage;
 import com.mishiranu.dashchan.ui.navigator.page.BoardsPage;
+import com.mishiranu.dashchan.ui.navigator.page.CombinedThreadsPage;
 import com.mishiranu.dashchan.ui.navigator.page.HistoryPage;
 import com.mishiranu.dashchan.ui.navigator.page.ListPage;
 import com.mishiranu.dashchan.ui.navigator.page.PostsPage;
@@ -17,6 +18,7 @@ import com.mishiranu.dashchan.ui.navigator.page.UserBoardsPage;
 public final class Page implements Parcelable {
 	public enum Content {
 		THREADS(ThreadsPage::new),
+		COMBINED_THREADS(CombinedThreadsPage::new),
 		POSTS(PostsPage::new),
 		SEARCH(SearchPage::new),
 		ARCHIVE(ArchivePage::new),
@@ -59,7 +61,8 @@ public final class Page implements Parcelable {
 	}
 
 	public boolean canDestroyIfNotInStack() {
-		return content == Content.SEARCH || content == Content.ARCHIVE || content == Content.BOARDS
+		return content == Content.COMBINED_THREADS || content == Content.SEARCH || content == Content.ARCHIVE
+				|| content == Content.BOARDS
 				|| content == Content.HISTORY;
 	}
 
@@ -68,12 +71,13 @@ public final class Page implements Parcelable {
 			String boardName = Preferences.getDefaultBoardName(Chan.get(chanName));
 			return boardName != null;
 		}
-		return content == Content.SEARCH || content == Content.ARCHIVE || content == Content.USER_BOARDS
+		return content == Content.COMBINED_THREADS || content == Content.SEARCH || content == Content.ARCHIVE
+				|| content == Content.USER_BOARDS
 				|| content == Content.HISTORY;
 	}
 
 	public boolean isMultiChanAllowed() {
-		return content == Content.HISTORY;
+		return content == Content.COMBINED_THREADS || content == Content.HISTORY;
 	}
 
 	public boolean isThreadsOrPosts(String chanName, String boardName, String threadNumber) {

--- a/src/com/mishiranu/dashchan/ui/navigator/adapter/ThreadsAdapter.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/adapter/ThreadsAdapter.java
@@ -30,6 +30,9 @@ import java.util.Locale;
 
 public class ThreadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements GalleryItem.Provider {
 	public interface Callback extends ListViewUtils.SimpleCallback<PostItem> {}
+	public interface SourceLabelProvider {
+		String getSourceLabel(PostItem postItem);
+	}
 
 	private static final int LIST_PADDING = 12;
 	private static final int CARD_MIN_WIDTH_LARGE_DP = 120;
@@ -58,6 +61,7 @@ public class ThreadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 	private final Context context;
 	private final UiManager uiManager;
 	private final UiManager.ConfigurationSet configurationSet;
+	private final SourceLabelProvider sourceLabelProvider;
 
 	private String filterText;
 	private Preferences.CatalogSort catalogSort = Preferences.CatalogSort.UNSORTED;
@@ -66,8 +70,15 @@ public class ThreadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
 	public ThreadsAdapter(Context context, Callback callback, String chanName, UiManager uiManager,
 			UiManager.PostStateProvider postStateProvider, FragmentManager fragmentManager) {
+		this(context, callback, chanName, uiManager, postStateProvider, fragmentManager, null);
+	}
+
+	public ThreadsAdapter(Context context, Callback callback, String chanName, UiManager uiManager,
+			UiManager.PostStateProvider postStateProvider, FragmentManager fragmentManager,
+			SourceLabelProvider sourceLabelProvider) {
 		this.context = context;
 		this.uiManager = uiManager;
+		this.sourceLabelProvider = sourceLabelProvider;
 		configurationSet = new UiManager.ConfigurationSet(chanName, null, null, postStateProvider,
 				this, fragmentManager, uiManager.dialog().createStackInstance(), null, callback,
 				false, false, false, false, false, null);
@@ -92,7 +103,8 @@ public class ThreadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 			case THREAD:
 			case THREAD_CARD: {
 				if (payloads.isEmpty()) {
-					uiManager.view().bindThreadView(holder, postItem, configurationSet);
+					uiManager.view().bindThreadView(holder, postItem, configurationSet,
+							sourceLabelProvider != null ? sourceLabelProvider.getSourceLabel(postItem) : null);
 				} else {
 					for (Object object : payloads) {
 						if (object instanceof AttachmentItem) {
@@ -111,7 +123,8 @@ public class ThreadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 			case THREAD_CARD_CELL: {
 				if (payloads.isEmpty()) {
 					uiManager.view().bindThreadCellView(holder, postItem, configurationSet,
-							gridMode.small, gridMode.gridItemContentHeight);
+							gridMode.small, gridMode.gridItemContentHeight,
+							sourceLabelProvider != null ? sourceLabelProvider.getSourceLabel(postItem) : null);
 				} else {
 					for (Object object : payloads) {
 						if (object instanceof AttachmentItem) {
@@ -340,7 +353,8 @@ public class ThreadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 	public void reloadAttachment(AttachmentItem attachmentItem) {
 		for (int i = 0; i < getItemCount(); i++) {
 			PostItem postItem = getItem(i);
-			if (postItem.getPostNumber().equals(attachmentItem.getPostNumber())) {
+			List<AttachmentItem> attachmentItems = postItem.getAttachmentItems();
+			if (attachmentItems != null && attachmentItems.contains(attachmentItem)) {
 				notifyItemChanged(i, attachmentItem);
 			}
 		}

--- a/src/com/mishiranu/dashchan/ui/navigator/manager/ViewUnit.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/manager/ViewUnit.java
@@ -241,6 +241,11 @@ public class ViewUnit {
 
 	public void bindThreadView(RecyclerView.ViewHolder viewHolder,
 			PostItem postItem, UiManager.ConfigurationSet configurationSet) {
+		bindThreadView(viewHolder, postItem, configurationSet, null);
+	}
+
+	public void bindThreadView(RecyclerView.ViewHolder viewHolder,
+			PostItem postItem, UiManager.ConfigurationSet configurationSet, String sourceLabel) {
 		Context context = uiManager.getContext();
 		ColorScheme colorScheme = ThemeEngine.getColorScheme(context);
 		ThreadViewHolder holder = (ThreadViewHolder) viewHolder;
@@ -275,6 +280,10 @@ public class ViewUnit {
 		holder.comment.setText(comment);
 		holder.comment.setVisibility(holder.comment.getText().length() > 0 ? View.VISIBLE : View.GONE);
 		holder.description.clear();
+		holder.description.setToEnd(StringUtils.isEmpty(sourceLabel) && holder.descriptionToEnd);
+		if (!StringUtils.isEmpty(sourceLabel)) {
+			holder.description.appendPreserveCase(sourceLabel);
+		}
 		postItem.formatThreadCardDescription(context.getResources(), false, holder.description::append);
 
 		List<AttachmentItem> attachmentItems = postItem.getAttachmentItems();
@@ -297,6 +306,12 @@ public class ViewUnit {
 
 	public void bindThreadCellView(RecyclerView.ViewHolder viewHolder,
 			PostItem postItem, UiManager.ConfigurationSet configurationSet, boolean small, int contentHeight) {
+		bindThreadCellView(viewHolder, postItem, configurationSet, small, contentHeight, null);
+	}
+
+	public void bindThreadCellView(RecyclerView.ViewHolder viewHolder,
+			PostItem postItem, UiManager.ConfigurationSet configurationSet, boolean small, int contentHeight,
+			String sourceLabel) {
 		Context context = uiManager.getContext();
 		ColorScheme colorScheme = ThemeEngine.getColorScheme(context);
 		ThreadViewHolder holder = (ThreadViewHolder) viewHolder;
@@ -336,6 +351,10 @@ public class ViewUnit {
 		holder.comment.setText(comment);
 		holder.comment.setVisibility(StringUtils.isEmpty(comment) ? View.GONE : View.VISIBLE);
 		holder.description.clear();
+		holder.description.setToEnd(StringUtils.isEmpty(sourceLabel) && holder.descriptionToEnd);
+		if (!StringUtils.isEmpty(sourceLabel)) {
+			holder.description.appendPreserveCase(sourceLabel);
+		}
 		postItem.formatThreadCardDescription(context.getResources(), true, holder.description::append);
 
 		if (attachmentItems != null && !hidden) {
@@ -1096,6 +1115,7 @@ public class ViewUnit {
 		public final TextView subject;
 		public final TextView comment;
 		public final ThreadDescriptionView description;
+		public final boolean descriptionToEnd;
 		public final ImageView[] stateImages;
 		public final View threadContent;
 		public final View showOriginalPost;
@@ -1140,11 +1160,12 @@ public class ViewUnit {
 			description.setTextColor(ThemeEngine.getTheme(description.getContext()).meta);
 			description.setTextSizeSp(11f * textScale);
 			description.setSpacing((int) (descriptionSpacingDp * density));
+			boolean descriptionToEnd;
 			if (threadViewType == ThreadViewType.CELL) {
 				thumbnail.setFitSquare(true);
 				ViewUtils.applyScaleSize(textScale, comment, subject);
 				stateImages = null;
-				description.setToEnd(true);
+				descriptionToEnd = true;
 			} else {
 				stateImages = new ImageView[PostState.THREAD_ITEM_STATES.size()];
 				fillStateImages(showOriginalPost, threadViewType == ThreadViewType.CARD ? 1 : 0,
@@ -1157,7 +1178,7 @@ public class ViewUnit {
 				ViewUtils.applyScaleSize(textScale, stateImages);
 				if (ResourceUtils.isTablet(itemView.getResources().getConfiguration()) &&
 						threadViewType == ThreadViewType.CARD) {
-					description.setToEnd(false);
+					descriptionToEnd = false;
 					int thumbnailSize = (int) (72f * density);
 					thumbnailLayoutParams.width = thumbnailSize;
 					thumbnailLayoutParams.height = thumbnailSize;
@@ -1167,7 +1188,7 @@ public class ViewUnit {
 							description.getPaddingRight(), description.getPaddingBottom());
 					comment.setMaxLines(8);
 				} else {
-					description.setToEnd(threadViewType != ThreadViewType.LIST);
+					descriptionToEnd = threadViewType != ThreadViewType.LIST;
 					comment.setMaxLines(6);
 				}
 				float thumbnailsScale = Preferences.getThumbnailsScale();
@@ -1176,6 +1197,8 @@ public class ViewUnit {
 					thumbnailLayoutParams.height = (int) (thumbnailLayoutParams.height * thumbnailsScale);
 				}
 			}
+			this.descriptionToEnd = descriptionToEnd;
+			description.setToEnd(descriptionToEnd);
 		}
 
 		@Override

--- a/src/com/mishiranu/dashchan/ui/navigator/page/CombinedThreadsPage.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/page/CombinedThreadsPage.java
@@ -1,0 +1,612 @@
+package com.mishiranu.dashchan.ui.navigator.page;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Pair;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.SubMenu;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModel;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import chan.content.Chan;
+import chan.content.RedirectException;
+import chan.http.HttpValidator;
+import chan.util.StringUtils;
+import com.mishiranu.dashchan.R;
+import com.mishiranu.dashchan.content.HidePerformer;
+import com.mishiranu.dashchan.content.Preferences;
+import com.mishiranu.dashchan.content.async.ReadThreadsTask;
+import com.mishiranu.dashchan.content.database.CommonDatabase;
+import com.mishiranu.dashchan.content.model.AttachmentItem;
+import com.mishiranu.dashchan.content.model.ErrorItem;
+import com.mishiranu.dashchan.content.model.PostItem;
+import com.mishiranu.dashchan.content.storage.CombinedFeedStorage;
+import com.mishiranu.dashchan.content.translation.TranslationController;
+import com.mishiranu.dashchan.ui.DialogMenu;
+import com.mishiranu.dashchan.ui.FragmentHandler;
+import com.mishiranu.dashchan.ui.InstanceDialog;
+import com.mishiranu.dashchan.ui.navigator.adapter.ThreadsAdapter;
+import com.mishiranu.dashchan.ui.navigator.manager.DialogUnit;
+import com.mishiranu.dashchan.ui.navigator.manager.UiManager;
+import com.mishiranu.dashchan.ui.preference.CombinedFeedsFragment;
+import com.mishiranu.dashchan.util.ConcurrentUtils;
+import com.mishiranu.dashchan.util.NavigationUtils;
+import com.mishiranu.dashchan.widget.ClickableToast;
+import com.mishiranu.dashchan.widget.DividerItemDecoration;
+import com.mishiranu.dashchan.widget.ListPosition;
+import com.mishiranu.dashchan.widget.PaddedRecyclerView;
+import com.mishiranu.dashchan.widget.PullableWrapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class CombinedThreadsPage extends ListPage implements ThreadsAdapter.Callback, UiManager.Observer,
+		CombinedFeedStorage.Observer {
+	private static class RetainableExtra implements Retainable {
+		public static final ExtraFactory<RetainableExtra> FACTORY = RetainableExtra::new;
+
+		public final ArrayList<PostItem> cachedPostItems = new ArrayList<>();
+		public final PostItem.HideState.Map<String> hiddenThreads = new PostItem.HideState.Map<>();
+		public int failedSources;
+		public String sourceSignature;
+		public Boolean translationEnabled;
+		public DialogUnit.StackInstance.State dialogsState;
+
+		@Override
+		public void clear() {
+			if (dialogsState != null) {
+				dialogsState.dropState();
+				dialogsState = null;
+			}
+		}
+	}
+
+	private static class SourceResult {
+		public final CombinedFeedStorage.Source source;
+		public final List<PostItem> postItems;
+		public final PostItem.HideState.Map<String> hiddenThreads;
+		public final ErrorItem errorItem;
+
+		private SourceResult(CombinedFeedStorage.Source source, List<PostItem> postItems,
+				PostItem.HideState.Map<String> hiddenThreads, ErrorItem errorItem) {
+			this.source = source;
+			this.postItems = postItems;
+			this.hiddenThreads = hiddenThreads;
+			this.errorItem = errorItem;
+		}
+	}
+
+	private static class LoadResult {
+		public final ArrayList<SourceResult> results;
+
+		private LoadResult(ArrayList<SourceResult> results) {
+			this.results = results;
+		}
+	}
+
+	public static class ReadViewModel extends ViewModel {
+		private final HashMap<String, ReadThreadsTask> tasks = new HashMap<>();
+		private final ArrayList<SourceResult> results = new ArrayList<>();
+		private final MutableLiveData<LoadResult> result = new MutableLiveData<>();
+		private int generation;
+
+		public boolean isLoading() {
+			return !tasks.isEmpty();
+		}
+
+		public void cancel() {
+			generation++;
+			cancelTasks();
+			result.setValue(null);
+		}
+
+		public void load(CombinedFeedStorage.Feed feed) {
+			cancelTasks();
+			result.setValue(null);
+			results.clear();
+			int generation = ++this.generation;
+			for (CombinedFeedStorage.Source sourceValue : feed.sources) {
+				CombinedFeedStorage.Source source = new CombinedFeedStorage.Source(sourceValue);
+				String key = source.chanName + '\n' + source.boardName;
+				Chan chan = Chan.get(source.chanName);
+				if (chan.name == null) {
+					results.add(new SourceResult(source, null, null,
+							new ErrorItem(ErrorItem.Type.UNSUPPORTED_SERVICE)));
+					continue;
+				}
+				ReadThreadsTask.Callback callback = new ReadThreadsTask.Callback() {
+					private void finish(List<PostItem> postItems,
+							PostItem.HideState.Map<String> hiddenThreads, ErrorItem errorItem) {
+						finishSource(generation, key,
+								new SourceResult(source, postItems, hiddenThreads, errorItem));
+					}
+
+					@Override
+					public void onReadThreadsSuccess(List<PostItem> postItems, int pageNumber, int boardSpeed,
+							boolean append, boolean checkModified, HttpValidator validator,
+							PostItem.HideState.Map<String> hiddenThreads) {
+						finish(postItems, hiddenThreads, null);
+					}
+
+					@Override
+					public void onReadThreadsRedirect(RedirectException.Target target) {
+						finish(null, null, new ErrorItem(ErrorItem.Type.INVALID_RESPONSE));
+					}
+
+					@Override
+					public void onReadThreadsFail(ErrorItem errorItem, int pageNumber) {
+						finish(null, null, errorItem);
+					}
+				};
+				ReadThreadsTask task = new ReadThreadsTask(callback, chan, source.boardName, 0, null, false);
+				tasks.put(key, task);
+				task.execute(ConcurrentUtils.PARALLEL_EXECUTOR);
+			}
+			if (tasks.isEmpty()) {
+				result.setValue(new LoadResult(new ArrayList<>(results)));
+			}
+		}
+
+		private void finishSource(int generation, String key, SourceResult sourceResult) {
+			if (generation != this.generation || tasks.remove(key) == null) {
+				return;
+			}
+			results.add(sourceResult);
+			if (tasks.isEmpty()) {
+				result.setValue(new LoadResult(new ArrayList<>(results)));
+			}
+		}
+
+		public void observe(LifecycleOwner owner, Observer<LoadResult> observer) {
+			result.observe(owner, value -> {
+				if (value != null) {
+					result.setValue(null);
+					observer.onChanged(value);
+				}
+			});
+		}
+
+		private void cancelTasks() {
+			for (ReadThreadsTask task : tasks.values()) {
+				task.cancel();
+			}
+			tasks.clear();
+		}
+
+		@Override
+		protected void onCleared() {
+			generation++;
+			cancelTasks();
+		}
+	}
+
+	private CombinedFeedStorage.Feed feed;
+	private HidePerformer hidePerformer;
+
+	private final UiManager.PostStateProvider postStateProvider = new UiManager.PostStateProvider() {
+		@Override
+		public boolean isHiddenResolve(PostItem postItem) {
+			if (postItem.getHideState() == PostItem.HideState.UNDEFINED) {
+				PostItem.HideState hideState = getRetainableExtra(RetainableExtra.FACTORY).hiddenThreads
+						.get(makeThreadKey(postItem));
+				if (hideState != PostItem.HideState.UNDEFINED) {
+					postItem.setHidden(hideState, null);
+				} else {
+					String reason = hidePerformer.checkHidden(Chan.get(postItem.getChanName()), postItem);
+					postItem.setHidden(reason != null ? PostItem.HideState.HIDDEN : PostItem.HideState.SHOWN, reason);
+				}
+			}
+			return postItem.getHideState().hidden;
+		}
+	};
+
+	private ThreadsAdapter getAdapter() {
+		return (ThreadsAdapter) getRecyclerView().getAdapter();
+	}
+
+	@Override
+	protected void onCreate() {
+		feed = CombinedFeedStorage.getInstance().getFeed(getPage().boardName);
+		if (feed == null || feed.sources.size() < 2) {
+			switchError(R.string.combined_feed_not_found);
+			return;
+		}
+		Context context = getContext();
+		PaddedRecyclerView recyclerView = getRecyclerView();
+		GridLayoutManager layoutManager = new GridLayoutManager(context, 1);
+		recyclerView.setLayoutManager(layoutManager);
+		hidePerformer = new HidePerformer(context);
+		UiManager uiManager = getUiManager();
+		uiManager.view().bindThreadsPostRecyclerView(recyclerView);
+		ThreadsAdapter adapter = new ThreadsAdapter(context, this, getPage().chanName, uiManager,
+				postStateProvider, getFragmentManager(), this::formatSourceLabel);
+		RetainableExtra retainableExtra = getRetainableExtra(RetainableExtra.FACTORY);
+		String sourceSignature = makeSourceSignature(feed);
+		if (!sourceSignature.equals(retainableExtra.sourceSignature)) {
+			retainableExtra.sourceSignature = sourceSignature;
+			retainableExtra.cachedPostItems.clear();
+			retainableExtra.hiddenThreads.clear();
+			retainableExtra.failedSources = 0;
+		}
+		if (retainableExtra.translationEnabled == null) {
+			retainableExtra.translationEnabled = TranslationController.isReadyForChan(getPage().chanName)
+					&& Preferences.isTranslationAutoEnabled();
+		}
+		adapter.setTranslationEnabled(Boolean.TRUE.equals(retainableExtra.translationEnabled));
+		recyclerView.setAdapter(adapter);
+		recyclerView.addItemDecoration(new RecyclerView.ItemDecoration() {
+			@Override
+			public void getItemOffsets(@NonNull android.graphics.Rect outRect, @NonNull android.view.View view,
+					@NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+				int column = ((GridLayoutManager.LayoutParams) view.getLayoutParams()).getSpanIndex();
+				adapter.applyItemPadding(view, parent.getChildAdapterPosition(view), column, outRect);
+			}
+		});
+		recyclerView.addItemDecoration(new DividerItemDecoration(context, adapter::configureDivider));
+		recyclerView.getPullable().setPullSides(PullableWrapper.Side.TOP);
+		layoutManager.setSpanCount(adapter.setThreadsView(Preferences.getThreadsView()));
+		adapter.applyFilter(getInitSearch().currentQuery);
+		uiManager.observable().register(this);
+		CombinedFeedStorage.getInstance().getObservable().register(this);
+
+		ListPosition listPosition = takeListPosition();
+		if (!retainableExtra.cachedPostItems.isEmpty()) {
+			adapter.setItems(Collections.singleton(retainableExtra.cachedPostItems), false);
+			if (listPosition != null) {
+				listPosition.apply(recyclerView);
+			}
+			if (retainableExtra.dialogsState != null) {
+				uiManager.dialog().restoreState(adapter.getConfigurationSet(), retainableExtra.dialogsState);
+				retainableExtra.dialogsState.dropState();
+				retainableExtra.dialogsState = null;
+			}
+		}
+		ReadViewModel readViewModel = getViewModel(ReadViewModel.class);
+		if (readViewModel.isLoading()) {
+			recyclerView.getPullable().startBusyState(PullableWrapper.Side.TOP);
+			if (adapter.isRealEmpty()) {
+				switchProgress();
+			}
+		} else if (adapter.isRealEmpty()) {
+			refresh(false);
+		}
+		readViewModel.observe(this, this::onLoadResult);
+	}
+
+	@Override
+	protected void onDestroy() {
+		if (getRecyclerView().getAdapter() != null) {
+			getUiManager().dialog().closeDialogs(getAdapter().getConfigurationSet().stackInstance);
+		}
+		getUiManager().observable().unregister(this);
+		CombinedFeedStorage.getInstance().getObservable().unregister(this);
+	}
+
+	@Override
+	protected void onNotifyAllAdaptersChanged() {
+		if (getRecyclerView().getAdapter() != null) {
+			getUiManager().dialog().notifyDataSetChangedToAll(getAdapter().getConfigurationSet().stackInstance);
+		}
+	}
+
+	@Override
+	protected void onRequestStoreExtra(boolean saveToStack) {
+		if (getRecyclerView().getAdapter() == null) {
+			return;
+		}
+		RetainableExtra extra = getRetainableExtra(RetainableExtra.FACTORY);
+		if (extra.dialogsState != null) {
+			extra.dialogsState.dropState();
+		}
+		extra.dialogsState = getAdapter().getConfigurationSet().stackInstance.collectState();
+	}
+
+	@Override
+	public Pair<String, String> obtainTitleSubtitle() {
+		String title = feed != null ? feed.title : getString(R.string.combined_feeds);
+		int count = feed != null ? feed.sources.size() : 0;
+		int failed = getRetainableExtra(RetainableExtra.FACTORY).failedSources;
+		String subtitle = getResources().getQuantityString(R.plurals.number_boards__format, count, count);
+		if (failed > 0) {
+			subtitle += " - " + getString(R.string.combined_feed_failed__format, failed);
+		}
+		return new Pair<>(title, subtitle);
+	}
+
+	private String formatSourceLabel(PostItem postItem) {
+		Chan chan = Chan.get(postItem.getChanName());
+		String title;
+		if ("dvach".equals(postItem.getChanName())) {
+			title = "2ch";
+		} else {
+			title = chan.name != null ? chan.configuration.getTitle() : postItem.getChanName();
+		}
+		if (StringUtils.isEmpty(title)) {
+			title = postItem.getChanName();
+		}
+		if (title.indexOf(' ') < 0) {
+			int dotIndex = title.indexOf('.');
+			if (dotIndex > 0) {
+				title = title.substring(0, dotIndex);
+			}
+		}
+		return title + " /" + postItem.getBoardName() + "/";
+	}
+
+	private static String makeThreadKey(PostItem postItem) {
+		return postItem.getChanName() + '\n' + postItem.getBoardName() + '\n' + postItem.getThreadNumber();
+	}
+
+	private static String makeSourceSignature(CombinedFeedStorage.Feed feed) {
+		StringBuilder builder = new StringBuilder().append(feed.showSticky).append('\n');
+		for (CombinedFeedStorage.Source source : feed.sources) {
+			builder.append(source.chanName).append('\n').append(source.boardName).append('\n');
+		}
+		return builder.toString();
+	}
+
+	private void refresh(boolean showPull) {
+		if (feed == null) {
+			return;
+		}
+		ReadViewModel viewModel = getViewModel(ReadViewModel.class);
+		viewModel.load(feed);
+		PaddedRecyclerView recyclerView = getRecyclerView();
+		recyclerView.getPullable().startBusyState(showPull ? PullableWrapper.Side.TOP : PullableWrapper.Side.BOTH);
+		if (showPull) {
+			switchList();
+		} else {
+			switchProgress();
+		}
+	}
+
+	private void onLoadResult(LoadResult loadResult) {
+		if (feed == null) {
+			return;
+		}
+		PaddedRecyclerView recyclerView = getRecyclerView();
+		recyclerView.getPullable().cancelBusyState();
+		ArrayList<PostItem> postItems = new ArrayList<>();
+		RetainableExtra extra = getRetainableExtra(RetainableExtra.FACTORY);
+		PostItem.HideState.Map<String> hiddenThreads = new PostItem.HideState.Map<>();
+		int failed = 0;
+		int succeeded = 0;
+		ErrorItem firstError = null;
+		for (SourceResult result : loadResult.results) {
+			if (result.errorItem != null) {
+				failed++;
+				if (firstError == null) {
+					firstError = result.errorItem;
+				}
+			} else if (result.postItems != null) {
+				succeeded++;
+				for (PostItem postItem : result.postItems) {
+					if (!feed.showSticky && postItem.isSticky()) {
+						continue;
+					}
+					postItems.add(postItem);
+					if (result.hiddenThreads != null) {
+						PostItem.HideState state = result.hiddenThreads.get(postItem.getThreadNumber());
+						if (state != PostItem.HideState.UNDEFINED) {
+							hiddenThreads.set(makeThreadKey(postItem), state);
+						}
+					}
+				}
+			}
+		}
+		postItems.sort((first, second) -> Long.compare(second.getThreadLatestTimestamp(),
+				first.getThreadLatestTimestamp()));
+		extra.failedSources = failed;
+		if (!postItems.isEmpty()) {
+			extra.hiddenThreads.clear();
+			extra.hiddenThreads.addAll(hiddenThreads);
+			extra.cachedPostItems.clear();
+			extra.cachedPostItems.addAll(postItems);
+			switchList();
+			int oldCount = getAdapter().getItemCount();
+			getAdapter().setItems(Collections.singleton(postItems), false);
+			recyclerView.scrollToPosition(0);
+			if (failed > 0) {
+				ClickableToast.show(getString(R.string.combined_feed_partial_failure__format,
+						failed, loadResult.results.size()));
+			}
+			if (oldCount == 0) {
+				showScaleAnimation();
+			}
+		} else if (firstError != null) {
+			if (succeeded > 0 || getAdapter().isRealEmpty()) {
+				extra.hiddenThreads.clear();
+				extra.cachedPostItems.clear();
+				switchError(firstError);
+			} else {
+				switchList();
+				ClickableToast.show(firstError);
+			}
+		} else {
+			extra.hiddenThreads.clear();
+			extra.cachedPostItems.clear();
+			switchError(R.string.empty_response);
+		}
+		notifyTitleChanged();
+	}
+
+	@Override
+	public void onItemClick(PostItem postItem) {
+		if (postItem == null) {
+			return;
+		}
+		if (postItem.getHideState().hidden) {
+			setThreadHideState(postItem, PostItem.HideState.SHOWN);
+			getAdapter().notifyDataSetChanged();
+		} else {
+			getUiManager().navigator().navigatePosts(postItem.getChanName(), postItem.getBoardName(),
+					postItem.getThreadNumber(), null, postItem.getSubjectOrComment());
+		}
+	}
+
+	@Override
+	public boolean onItemLongClick(PostItem postItem) {
+		if (postItem != null) {
+			showItemPopupMenu(getFragmentManager(), postItem);
+			return true;
+		}
+		return false;
+	}
+
+	private static void showItemPopupMenu(FragmentManager fragmentManager, PostItem postItem) {
+		new InstanceDialog(fragmentManager, null, provider -> {
+			CombinedThreadsPage page = extract(provider);
+			Chan chan = Chan.get(postItem.getChanName());
+			Uri uri = chan.locator.safe(true).createThreadUri(postItem.getBoardName(), postItem.getThreadNumber());
+			DialogMenu menu = new DialogMenu(provider.getContext());
+			if (uri != null) {
+				menu.add(R.string.copy_link,
+						() -> StringUtils.copyToClipboard(provider.getContext(), uri.toString()));
+				menu.add(R.string.share_link, () -> {
+					String subject = postItem.getSubjectOrComment();
+					NavigationUtils.shareLink(provider.getContext(), StringUtils.isEmptyOrWhitespace(subject)
+							? uri.toString() : subject, uri);
+				});
+			}
+			if (!postItem.getHideState().hidden) {
+				menu.add(R.string.hide, () -> {
+					page.setThreadHideState(postItem, PostItem.HideState.HIDDEN);
+					page.getAdapter().notifyThreadHidden(postItem);
+				});
+			}
+			return menu.create();
+		});
+	}
+
+	private void setThreadHideState(PostItem postItem, PostItem.HideState hideState) {
+		getRetainableExtra(RetainableExtra.FACTORY).hiddenThreads.set(makeThreadKey(postItem), hideState);
+		CommonDatabase.getInstance().getThreads().setFlagsAsync(postItem.getChanName(), postItem.getBoardName(),
+				postItem.getThreadNumber(), hideState);
+		postItem.setHidden(hideState, null);
+	}
+
+	@Override
+	public void onCreateOptionsMenu(Menu menu) {
+		if (feed == null) {
+			return;
+		}
+		menu.add(0, R.id.menu_refresh, 0, R.string.refresh)
+				.setIcon(getActionBarIcon(R.attr.iconActionRefresh))
+				.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+		menu.add(0, R.id.menu_translate, 0, R.string.translate_posts)
+				.setIcon(getActionBarIcon(R.attr.iconActionTranslate))
+				.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+		menu.add(0, R.id.menu_search, 0, R.string.filter)
+				.setShowAsAction(MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
+		menu.add(0, R.id.menu_configure_feed, 0, R.string.configure_combined_feed);
+		menu.addSubMenu(0, R.id.menu_appearance, 0, R.string.appearance);
+		SubMenu viewOptions = menu.addSubMenu(0, R.id.menu_threads_view, 0, R.string.threads_view);
+		for (Preferences.ThreadsView threadsView : Preferences.ThreadsView.values()) {
+			viewOptions.add(R.id.menu_threads_view, threadsView.menuItemId, 0, threadsView.titleResId);
+		}
+		viewOptions.setGroupCheckable(R.id.menu_threads_view, true, true);
+	}
+
+	@Override
+	public void onPrepareOptionsMenu(Menu menu) {
+		if (feed == null || getRecyclerView().getAdapter() == null) {
+			return;
+		}
+		boolean enabled = TranslationController.isEnabledForChan(getPage().chanName);
+		MenuItem translate = menu.findItem(R.id.menu_translate);
+		translate.setVisible(enabled);
+		if (enabled) {
+			translate.setTitle(getAdapter().isTranslationEnabled()
+					? R.string.show_original_posts : R.string.translate_posts);
+		}
+		menu.findItem(Preferences.getThreadsView().menuItemId).setChecked(true);
+	}
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		if (feed == null || getRecyclerView().getAdapter() == null) {
+			return false;
+		}
+		if (item.getItemId() == R.id.menu_refresh) {
+			refresh(true);
+			return true;
+		}
+		if (item.getItemId() == R.id.menu_translate) {
+			if (!TranslationController.isReadyForChan(getPage().chanName)) {
+				ClickableToast.show(R.string.translation_package_unavailable);
+				return true;
+			}
+			boolean enabled = !getAdapter().isTranslationEnabled();
+			getRetainableExtra(RetainableExtra.FACTORY).translationEnabled = enabled;
+			getAdapter().setTranslationEnabled(enabled);
+			updateOptionsMenu();
+			return true;
+		}
+		if (item.getItemId() == R.id.menu_configure_feed) {
+			Context context = getContext();
+			if (context instanceof FragmentHandler) {
+				((FragmentHandler) context).pushFragment(CombinedFeedsFragment.forFeed(feed.id));
+				return true;
+			}
+		}
+		for (Preferences.ThreadsView threadsView : Preferences.ThreadsView.values()) {
+			if (item.getItemId() == threadsView.menuItemId) {
+				Preferences.setThreadsView(threadsView);
+				GridLayoutManager manager = (GridLayoutManager) getRecyclerView().getLayoutManager();
+				manager.setSpanCount(getAdapter().setThreadsView(threadsView));
+				getAdapter().notifyDataSetChanged();
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void onSearchQueryChange(String query) {
+		if (getRecyclerView().getAdapter() != null) {
+			getAdapter().applyFilter(query);
+		}
+	}
+
+	@Override
+	public void onListPulled(PullableWrapper wrapper, PullableWrapper.Side side) {
+		refresh(true);
+	}
+
+	@Override
+	public void onAppearanceOptionChanged(int what) {
+		if (getRecyclerView().getAdapter() != null &&
+				(what == R.id.menu_spoilers || what == R.id.menu_sfw_mode)) {
+			notifyAllAdaptersChanged();
+		}
+	}
+
+	@Override
+	public void onReloadAttachmentItem(AttachmentItem attachmentItem) {
+		getAdapter().reloadAttachment(attachmentItem);
+	}
+
+	@Override
+	public void onCombinedFeedsChanged() {
+		CombinedFeedStorage.Feed newFeed = CombinedFeedStorage.getInstance().getFeed(getPage().boardName);
+		if (newFeed == null) {
+			feed = null;
+			getViewModel(ReadViewModel.class).cancel();
+			getRecyclerView().getPullable().cancelBusyState();
+			switchError(R.string.combined_feed_not_found);
+			notifyTitleChanged();
+		} else {
+			feed = newFeed;
+			getRetainableExtra(RetainableExtra.FACTORY).sourceSignature = makeSourceSignature(newFeed);
+			refresh(!getAdapter().isRealEmpty());
+			notifyTitleChanged();
+		}
+	}
+}

--- a/src/com/mishiranu/dashchan/ui/preference/CombinedFeedsFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/CombinedFeedsFragment.java
@@ -1,0 +1,293 @@
+package com.mishiranu.dashchan.ui.preference;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import androidx.annotation.NonNull;
+import chan.content.Chan;
+import chan.util.StringUtils;
+import com.mishiranu.dashchan.R;
+import com.mishiranu.dashchan.content.Preferences;
+import com.mishiranu.dashchan.content.async.GetBoardsTask;
+import com.mishiranu.dashchan.content.async.ReadBoardsTask;
+import com.mishiranu.dashchan.content.database.ChanDatabase;
+import com.mishiranu.dashchan.content.storage.CombinedFeedStorage;
+import com.mishiranu.dashchan.ui.FragmentHandler;
+import com.mishiranu.dashchan.ui.preference.core.Preference;
+import com.mishiranu.dashchan.ui.preference.core.PreferenceFragment;
+import com.mishiranu.dashchan.util.ConcurrentUtils;
+import com.mishiranu.dashchan.util.ResourceUtils;
+import com.mishiranu.dashchan.util.SharedPreferences;
+import com.mishiranu.dashchan.widget.ClickableToast;
+import com.mishiranu.dashchan.widget.SafePasteEditText;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+public class CombinedFeedsFragment extends PreferenceFragment implements GetBoardsTask.Callback,
+		ReadBoardsTask.Callback, CombinedFeedStorage.Observer {
+	private static final String EXTRA_EDIT_FEED_ID = "editFeedId";
+
+	public static CombinedFeedsFragment forFeed(String feedId) {
+		CombinedFeedsFragment fragment = new CombinedFeedsFragment();
+		Bundle arguments = new Bundle();
+		arguments.putString(EXTRA_EDIT_FEED_ID, feedId);
+		fragment.setArguments(arguments);
+		return fragment;
+	}
+
+	private static class Board {
+		public final String name;
+		public final String title;
+
+		private Board(String name, String title) {
+			this.name = name;
+			this.title = title;
+		}
+	}
+
+	private final ArrayList<Board> boards = new ArrayList<>();
+	private GetBoardsTask getBoardsTask;
+	private ReadBoardsTask readBoardsTask;
+	private boolean boardsLoaded;
+	private boolean refreshAttempted;
+	private String pendingEditFeedId;
+
+	@Override
+	protected SharedPreferences getPreferences() {
+		return Preferences.PREFERENCES;
+	}
+
+	@Override
+	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+		if (savedInstanceState == null && getArguments() != null) {
+			pendingEditFeedId = getArguments().getString(EXTRA_EDIT_FEED_ID);
+		}
+		CombinedFeedStorage.getInstance().getObservable().register(this);
+		refreshPreferences();
+		getBoardsTask = new GetBoardsTask(this, Chan.get("dvach"), null, null);
+		getBoardsTask.execute(ConcurrentUtils.PARALLEL_EXECUTOR);
+	}
+
+	private void refreshPreferences() {
+		if (getView() == null) {
+			return;
+		}
+		removeAllPreferences();
+		Preference<Void> addFeed = addButton(R.string.add_combined_feed, boardsLoaded
+				? R.string.combined_feeds_add__summary : R.string.loading__ellipsis);
+		addFeed.setEnabled(boardsLoaded);
+		addFeed.setOnClickListener(p -> showFeedDialog(null));
+		List<CombinedFeedStorage.Feed> feeds = CombinedFeedStorage.getInstance().getFeeds();
+		if (feeds.isEmpty()) {
+			addHeader(R.string.combined_feeds_empty);
+		} else {
+			addHeader(R.string.combined_feeds);
+			for (CombinedFeedStorage.Feed feed : feeds) {
+				addButton(feed.title, formatSources(feed.sources)).setOnClickListener(p -> showFeedDialog(feed));
+			}
+		}
+	}
+
+	private static String formatSources(List<CombinedFeedStorage.Source> sources) {
+		StringBuilder builder = new StringBuilder();
+		for (CombinedFeedStorage.Source source : sources) {
+			if (builder.length() > 0) {
+				builder.append(", ");
+			}
+			builder.append('/').append(source.boardName).append('/');
+		}
+		return builder.toString();
+	}
+
+	private void showFeedDialog(CombinedFeedStorage.Feed existing) {
+		if (!boardsLoaded) {
+			ClickableToast.show(R.string.loading__ellipsis);
+			return;
+		}
+		float density = ResourceUtils.obtainDensity(requireContext());
+		int padding = getResources().getDimensionPixelSize(R.dimen.dialog_padding_view);
+		LinearLayout root = new LinearLayout(requireContext());
+		root.setOrientation(LinearLayout.VERTICAL);
+		root.setPadding(padding, padding, padding, 0);
+		EditText name = new SafePasteEditText(requireContext());
+		name.setSingleLine(true);
+		name.setHint(R.string.combined_feed_name);
+		name.setText(existing != null ? existing.title : "");
+		name.setSelection(name.length());
+		root.addView(name, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+		CheckBox showSticky = new CheckBox(requireContext());
+		showSticky.setText(R.string.show_sticky_threads);
+		showSticky.setChecked(existing == null || existing.showSticky);
+		root.addView(showSticky, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+
+		HashSet<String> selected = new HashSet<>();
+		if (existing != null) {
+			for (CombinedFeedStorage.Source source : existing.sources) {
+				if ("dvach".equals(source.chanName)) {
+					selected.add(source.boardName);
+				}
+			}
+		}
+		LinearLayout checks = new LinearLayout(requireContext());
+		checks.setOrientation(LinearLayout.VERTICAL);
+		ArrayList<CheckBox> checkBoxes = new ArrayList<>(boards.size());
+		for (Board board : boards) {
+			CheckBox checkBox = new CheckBox(requireContext());
+			checkBox.setText(board.title);
+			checkBox.setTag(board.name);
+			checkBox.setChecked(selected.contains(board.name));
+			checks.addView(checkBox, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+			checkBoxes.add(checkBox);
+		}
+		ScrollView scrollView = new ScrollView(requireContext());
+		scrollView.addView(checks, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+		root.addView(scrollView, ViewGroup.LayoutParams.MATCH_PARENT, (int) (320f * density));
+
+		AlertDialog.Builder builder = new AlertDialog.Builder(requireContext())
+				.setTitle(existing != null ? R.string.edit_combined_feed : R.string.add_combined_feed)
+				.setView(root)
+				.setNegativeButton(android.R.string.cancel, null)
+				.setPositiveButton(android.R.string.ok, null);
+		if (existing != null) {
+			builder.setNeutralButton(R.string.delete, null);
+		}
+		AlertDialog dialog = builder.create();
+		dialog.setOnShowListener(ignored -> {
+			dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(button -> {
+				String title = name.getText().toString().trim();
+				ArrayList<String> selectedBoards = new ArrayList<>();
+				for (CheckBox checkBox : checkBoxes) {
+					if (checkBox.isChecked()) {
+						selectedBoards.add((String) checkBox.getTag());
+					}
+				}
+				if (StringUtils.isEmptyOrWhitespace(title)) {
+					ClickableToast.show(R.string.combined_feed_name_required);
+					return;
+				}
+				if (selectedBoards.size() < 2) {
+					ClickableToast.show(R.string.combined_feed_minimum_boards);
+					return;
+				}
+				CombinedFeedStorage.Feed feed = new CombinedFeedStorage.Feed();
+				feed.id = existing != null ? existing.id : null;
+				feed.title = title;
+				feed.showSticky = showSticky.isChecked();
+				for (String boardName : selectedBoards) {
+					feed.sources.add(new CombinedFeedStorage.Source("dvach", boardName));
+				}
+				if (CombinedFeedStorage.getInstance().put(feed)) {
+					dialog.dismiss();
+				} else {
+					ClickableToast.show(R.string.combined_feeds_limit);
+				}
+			});
+			if (existing != null) {
+				dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(button ->
+						new AlertDialog.Builder(requireContext())
+								.setMessage(R.string.delete_combined_feed_confirmation)
+								.setNegativeButton(android.R.string.cancel, null)
+								.setPositiveButton(R.string.delete, (confirmation, which) -> {
+									CombinedFeedStorage.getInstance().remove(existing.id);
+									dialog.dismiss();
+								}).show());
+			}
+		});
+		dialog.show();
+	}
+
+	@Override
+	public void onGetBoardsResult(ChanDatabase.BoardCursor cursor) {
+		getBoardsTask = null;
+		boards.clear();
+		if (cursor != null) {
+			try {
+				if (cursor.moveToFirst()) {
+					ChanDatabase.BoardItem item = new ChanDatabase.BoardItem();
+					do {
+						item.update(cursor);
+						boards.add(new Board(item.boardName,
+								StringUtils.formatBoardTitle("", item.boardName, item.extra1)));
+					} while (cursor.moveToNext());
+				}
+			} finally {
+				cursor.close();
+			}
+		}
+		Collections.sort(boards, (first, second) ->
+				String.CASE_INSENSITIVE_ORDER.compare(first.title, second.title));
+		boardsLoaded = !boards.isEmpty();
+		if (!boardsLoaded && !refreshAttempted) {
+			refreshAttempted = true;
+			readBoardsTask = new ReadBoardsTask(this, Chan.get("dvach"));
+			readBoardsTask.execute(ConcurrentUtils.PARALLEL_EXECUTOR);
+			return;
+		}
+		refreshPreferences();
+		openPendingFeedIfReady();
+		if (!boardsLoaded && readBoardsTask == null) {
+			ClickableToast.show(R.string.combined_feeds_boards_unavailable);
+		}
+	}
+
+	private void openPendingFeedIfReady() {
+		if (!boardsLoaded || StringUtils.isEmpty(pendingEditFeedId)) {
+			return;
+		}
+		String feedId = pendingEditFeedId;
+		pendingEditFeedId = null;
+		CombinedFeedStorage.Feed feed = CombinedFeedStorage.getInstance().getFeed(feedId);
+		if (feed != null) {
+			showFeedDialog(feed);
+		} else {
+			ClickableToast.show(R.string.combined_feed_not_found);
+		}
+	}
+
+	@Override
+	public void onReadBoardsSuccess() {
+		readBoardsTask = null;
+		getBoardsTask = new GetBoardsTask(this, Chan.get("dvach"), null, null);
+		getBoardsTask.execute(ConcurrentUtils.PARALLEL_EXECUTOR);
+	}
+
+	@Override
+	public void onReadBoardsFail(com.mishiranu.dashchan.content.model.ErrorItem errorItem) {
+		readBoardsTask = null;
+		refreshPreferences();
+		ClickableToast.show(errorItem);
+	}
+
+	@Override
+	public void onCombinedFeedsChanged() {
+		refreshPreferences();
+	}
+
+	@Override
+	public void onDestroyView() {
+		if (getBoardsTask != null) {
+			getBoardsTask.cancel();
+			getBoardsTask = null;
+		}
+		if (readBoardsTask != null) {
+			readBoardsTask.cancel();
+			readBoardsTask = null;
+		}
+		CombinedFeedStorage.getInstance().getObservable().unregister(this);
+		super.onDestroyView();
+	}
+
+	@Override
+	public void onActivityCreated(Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+		((FragmentHandler) requireActivity()).setTitleSubtitle(getString(R.string.combined_feeds), null);
+	}
+}

--- a/src/com/mishiranu/dashchan/ui/preference/ExperimentalFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/ExperimentalFragment.java
@@ -66,6 +66,15 @@ public class ExperimentalFragment extends PreferenceFragment implements Translat
 				Preferences.DEFAULT_OPEN_CONFIGURED_ATTACHMENT_FOLDER,
 				R.string.open_configured_attachment_folder,
 				R.string.open_configured_attachment_folder__summary);
+		CheckPreference combinedFeedsPreference = addCheck(true, Preferences.KEY_COMBINED_FEEDS_ENABLED,
+				Preferences.DEFAULT_COMBINED_FEEDS_ENABLED, R.string.combined_feeds,
+				R.string.combined_feeds__summary);
+		combinedFeedsPreference.setOnAfterChangeListener(p -> refreshPreferences());
+		if (combinedFeedsPreference.getValue()) {
+			addButton(R.string.configure_combined_feeds, R.string.configure_combined_feeds__summary)
+					.setOnClickListener(p -> ((FragmentHandler) requireActivity())
+							.pushFragment(new CombinedFeedsFragment()));
+		}
 		if (BuildConfig.ENABLE_LOCAL_TRANSLATION) {
 			addTranslationPreferences();
 		}

--- a/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
+++ b/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
@@ -41,6 +41,10 @@ public final class SettingsSearchIndex {
 			@Override
 			ContentFragment createFragment() { return new InterfaceFragment(); }
 		},
+		COMBINED_FEEDS(R.string.experimental_features, R.string.combined_feeds) {
+			@Override
+			ContentFragment createFragment() { return new CombinedFeedsFragment(); }
+		},
 		GESTURES(R.string.user_interface, R.string.gesture_controls) {
 			@Override
 			ContentFragment createFragment() { return new GestureSettingsFragment(); }
@@ -328,6 +332,10 @@ public final class SettingsSearchIndex {
 		}
 		add(context, entries, Screen.EXPERIMENTAL, R.string.video_diagnostics_start,
 				R.string.video_diagnostics_start__summary, null);
+		add(context, entries, Screen.EXPERIMENTAL, R.string.combined_feeds,
+				R.string.combined_feeds__summary, Preferences.KEY_COMBINED_FEEDS_ENABLED);
+		add(context, entries, Screen.COMBINED_FEEDS, R.string.configure_combined_feeds,
+				R.string.configure_combined_feeds__summary, null);
 
 		add(context, entries, Screen.INTERFACE, R.string.application_name, 0, Preferences.KEY_APPLICATION_NAME);
 		add(context, entries, Screen.INTERFACE, R.string.application_logo);

--- a/src/com/mishiranu/dashchan/util/WebViewUtils.java
+++ b/src/com/mishiranu/dashchan/util/WebViewUtils.java
@@ -20,6 +20,7 @@ import androidx.webkit.WebViewFeature;
 import chan.http.HttpClient;
 import chan.util.StringUtils;
 import com.mishiranu.dashchan.content.MainApplication;
+import com.mishiranu.dashchan.content.net.UserAgentProvider;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -32,6 +33,7 @@ public class WebViewUtils {
 		settings.setAllowFileAccessFromFileURLs(false);
 		settings.setAllowUniversalAccessFromFileURLs(false);
 		settings.setSafeBrowsingEnabled(true);
+		settings.setUserAgentString(UserAgentProvider.getInstance().getUserAgent());
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/com/mishiranu/dashchan/widget/ThreadDescriptionView.java
+++ b/src/com/mishiranu/dashchan/widget/ThreadDescriptionView.java
@@ -67,6 +67,14 @@ public class ThreadDescriptionView extends View {
 		invalidate();
 	}
 
+	public void appendPreserveCase(String value) {
+		if (!StringUtils.isEmpty(value)) {
+			description.add(value);
+			shortDescription.clear();
+		}
+		invalidate();
+	}
+
 	private void prepareShortDescription() {
 		if (shortDescription.isEmpty()) {
 			StringBuilder builder = new StringBuilder();

--- a/unitTests/src/com/mishiranu/dashchan/content/net/UserAgentProviderTest.java
+++ b/unitTests/src/com/mishiranu/dashchan/content/net/UserAgentProviderTest.java
@@ -1,0 +1,61 @@
+package com.mishiranu.dashchan.content.net;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UserAgentProviderTest {
+	private static final String PREFIX = "Mozilla/5.0 (Linux; Android 10; K; wv) " +
+			"AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/";
+	private static final String SUFFIX = ".0.0.0 Mobile Safari/537.36";
+
+	@Test
+	public void sanitizesDeviceAndFirmwareData() {
+		String source = "Mozilla/5.0 (Linux; Android 16; Pixel 9 Pro Build/AP3A.260715.001; wv) " +
+				"AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 " +
+				"Chrome/150.0.6724.102 Mobile Safari/537.36";
+		String result = UserAgentProvider.sanitizeUserAgent(source);
+
+		Assert.assertEquals(PREFIX + "150" + SUFFIX, result);
+		Assert.assertFalse(result.contains("Pixel 9 Pro"));
+		Assert.assertFalse(result.contains("AP3A.260715.001"));
+		Assert.assertFalse(result.contains("150.0.6724.102"));
+	}
+
+	@Test
+	public void keepsOnlyChromiumMajor() {
+		Assert.assertEquals(PREFIX + "150" + SUFFIX,
+				UserAgentProvider.sanitizeUserAgent("Chrome/150.0.6724.102"));
+	}
+
+	@Test
+	public void producesSameResultForDifferentDevices() {
+		String first = UserAgentProvider.sanitizeUserAgent(
+				"Mozilla/5.0 (Linux; Android 14; Phone One Build/A.1; wv) Chrome/149.1.2.3");
+		String second = UserAgentProvider.sanitizeUserAgent(
+				"Mozilla/5.0 (Linux; Android 16; Phone Two Build/B.9; wv) Chrome/149.9.8.7");
+
+		Assert.assertEquals(first, second);
+		Assert.assertEquals(PREFIX + "149" + SUFFIX, first);
+	}
+
+	@Test
+	public void handlesUserAgentWithoutBuildToken() {
+		Assert.assertEquals(PREFIX + "148" + SUFFIX,
+				UserAgentProvider.sanitizeUserAgent(
+						"Mozilla/5.0 (Linux; Android 15; wv) AppleWebKit/537.36 Chrome/148.2.3.4"));
+	}
+
+	@Test
+	public void usesPrivacySafeFallbackForUnexpectedInput() {
+		String expected = PREFIX + "100" + SUFFIX;
+		Assert.assertEquals(expected, UserAgentProvider.sanitizeUserAgent(null));
+		Assert.assertEquals(expected, UserAgentProvider.sanitizeUserAgent("Mozilla/5.0"));
+		Assert.assertEquals(expected, UserAgentProvider.sanitizeUserAgent("Chrome/not-a-version"));
+	}
+
+	@Test
+	public void acceptsChromiumProductName() {
+		Assert.assertEquals(PREFIX + "147" + SUFFIX,
+				UserAgentProvider.sanitizeUserAgent("Chromium/147.12.34.56"));
+	}
+}


### PR DESCRIPTION
## Summary

- bump the stable application version to 3.2.22 (11020);
- add configurable experimental My feeds that combine multiple Dvach boards, support sticky-thread filtering, backup/restore and direct feed configuration;
- improve precise video seeking after hardware-decoder playback;
- reduce side-drawer work and run drawer-close and destination transitions concurrently;
- centralize a reduced WebView User-Agent that does not expose the real device model, firmware build or full Android version;
- fix explicit HTTP User-Agent header forwarding and add User-Agent unit coverage.

## Motivation

This combines the device-tested video-seek and drawer work with the new My feeds feature and the WebView privacy correction for the next stable GitHub release.

## Validation

- rebased onto the current master;
- `git diff --check` passed;
- version metadata parsed and contains exactly one 3.2.22 (11020) declaration;
- stable `update/data.json` is unchanged;
- source diff audit found no local paths, credentials, tokens or beta-only captcha/no-captcha functionality;
- a local signed arm64 test APK was manually exercised; additional low-performance-device feedback is pending;
- no Gradle build was run during this source-only PR preparation; GitHub CI is expected to provide the build check.