### PR TITLE
Publish Slooop 3.2.24 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,14 +5,14 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.23",
-			"code": 11030,
+			"name": "3.2.24",
+			"code": 11040,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 44560921,
-			"sha256sum": "68d7d2a0977aed5ba6972e64b783996dddc51d1344fd7adbd12de00deb563fec",
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.23/Slooop-3.2.23-11030-ffmpeg8-all-abi-signed.apk",
+			"length": 44618534,
+			"sha256sum": "b55ce7bf485ee32f356c68279156e5a2c1bbebdc19094f91bac4406e1f954fc1",
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.24/Slooop-3.2.24-11040-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
Updates only the stable update manifest with the verified public Slooop 3.2.24 APK URL, size, SHA-256, version code, and existing signing fingerprint.