### PR TITLE
Retire beta update channel

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -195,7 +195,7 @@ jobs:
           ./gradlew --no-daemon --stacktrace "$BUILD_TASK" "${gradle_args[@]}" \
             2>&1 | tee build-main.log
 
-      - name: Verify update-channel distribution boundary
+      - name: Verify retired beta update channel is absent
         if: steps.validation.outputs.build_required == 'true'
         run: |
           set -euo pipefail
@@ -218,18 +218,11 @@ jobs:
               echo "Beta update reference found in $apk"
             fi
           done
-          if [ "$BUILD_TASK" = 'assembleFdroidRelease' ]; then
-            if [ "$beta_reference_found" = true ]; then
-              echo '::error::F-Droid APK contains the GitHub beta update repository reference'
-              exit 1
-            fi
-            echo 'F-Droid APK contains no GitHub beta update repository reference'
-          elif [ "$beta_reference_found" != true ]; then
-            echo '::error::GitHub APK lost its configured beta update repository reference'
+          if [ "$beta_reference_found" = true ]; then
+            echo '::error::APK contains the retired beta update repository reference'
             exit 1
-          else
-            echo 'GitHub APK retains its configured beta update repository reference'
           fi
+          echo 'APK contains no retired beta update repository reference'
 
       - name: Create APK checksums
         if: steps.validation.outputs.build_required == 'true'

--- a/build.gradle
+++ b/build.gradle
@@ -306,22 +306,19 @@ android {
 			buildConfigField 'boolean', 'ENABLE_GEMINI_NANO_TRANSLATION', 'true'
 			buildConfigField 'boolean', 'ALLOW_GMS_SECURITY_PROVIDER', 'true'
 			buildConfigField 'boolean', 'ALLOW_APPLICATION_SELF_UPDATE', 'true'
-			buildConfigField 'boolean', 'ALLOW_BETA_UPDATE_CHANNEL', 'true'
+			buildConfigField 'boolean', 'ALLOW_BETA_UPDATE_CHANNEL', 'false'
 			buildConfigField 'boolean', 'REQUIRE_EXTENSION_INSTALL_CONSENT', 'false'
-			buildConfigField 'String', 'GITHUB_URI_METADATA_BETA',
-					'"//github.com/andrewpozdnakov7-jpg/Dashchan_2_Update_Test"'
-			buildConfigField 'String', 'GITHUB_PATH_METADATA_BETA', '"metadata"'
+			buildConfigField 'String', 'GITHUB_URI_METADATA_BETA', '""'
+			buildConfigField 'String', 'GITHUB_PATH_METADATA_BETA', '""'
 			buildConfigField 'String', 'URI_UPDATES', '"//raw.githubusercontent.com/' +
 					'andrewpozdnakov7-jpg/Dashchan_2/master/update/data.json"'
-			buildConfigField 'String', 'URI_UPDATES_BETA', '"//raw.githubusercontent.com/' +
-					'andrewpozdnakov7-jpg/Dashchan_2_Update_Test/master/update/data.json"'
+			buildConfigField 'String', 'URI_UPDATES_BETA', '""'
 			buildConfigField 'String', 'UPDATE_MANIFEST_URL', '""'
 			buildConfigField 'String', 'UPDATE_MANIFEST_BETA_URL', '""'
 			buildConfigField 'String', 'UPDATE_GITHUB_RELEASES_URL',
 					'"https://api.github.com/repos/andrewpozdnakov7-jpg/Dashchan_2/releases"'
 			buildConfigField 'String', 'UPDATE_GITHUB_LATEST_RELEASE_URL', '""'
-			buildConfigField 'String', 'UPDATE_GITHUB_BETA_RELEASES_URL',
-					'"https://api.github.com/repos/andrewpozdnakov7-jpg/Dashchan_2_Update_Test/releases"'
+			buildConfigField 'String', 'UPDATE_GITHUB_BETA_RELEASES_URL', '""'
 			buildConfigField 'String', 'UPDATE_GITHUB_BETA_LATEST_RELEASE_URL', '""'
 		}
 		fdroid {

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -45,4 +45,5 @@
 - [ ] Commit and push the manifest separately.
 - [ ] Read the published manifest from GitHub and confirm that the app discovers the update.
 
-Beta releases use the separate `Dashchan_2_Update_Test` repository and must never replace the stable manifest until promoted.
+The beta update channel is discontinued. Keep `ALLOW_BETA_UPDATE_CHANNEL` disabled and all beta metadata and
+release URLs empty in every distribution flavor.

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -654,6 +654,9 @@ public class Preferences {
 
 	public static UpdateChannel getUpdateChannel() {
 		if (!BuildConfig.ALLOW_BETA_UPDATE_CHANNEL) {
+			if (PREFERENCES != null && PREFERENCES.contains(KEY_UPDATE_CHANNEL)) {
+				PREFERENCES.edit().remove(KEY_UPDATE_CHANNEL).close();
+			}
 			return UpdateChannel.STABLE;
 		}
 		String value = PREFERENCES.getString(KEY_UPDATE_CHANNEL, DEFAULT_UPDATE_CHANNEL.value);

--- a/update/README.md
+++ b/update/README.md
@@ -7,7 +7,8 @@ This directory contains the public metadata consumed by Dashchan_2.
 - `data.json`: stable update manifest loaded through `BuildConfig.URI_UPDATES`;
 - `themes.json`: downloadable theme catalog loaded through `BuildConfig.URI_THEMES`.
 
-The opt-in beta channel reads `update/data.json` from the separate public [`Dashchan_2_Update_Test`](https://github.com/andrewpozdnakov7-jpg/Dashchan_2_Update_Test) repository. Stable clients never use beta releases unless the user changes the update channel.
+The former opt-in beta update channel is discontinued. `data.json` is the only application update manifest and
+contains stable releases only.
 
 ## Stable Manifest
 


### PR DESCRIPTION
## Summary

- disables the beta update channel in the GitHub distribution;
- clears every beta metadata, manifest, and GitHub Releases endpoint;
- removes a previously stored beta-channel preference and falls back to stable updates;
- updates release and update documentation to mark the beta channel as discontinued.

## Scope

The stable self-update path remains enabled. The stable `update/data.json`, version, beta-only functionality, F-Droid files, tags, and releases are unchanged.

## Checks

- `git diff --check`
- exact four-file scope verified against `master`
- beta endpoint and beta-only source scan
- added-line secret, local-path, and de-anonymization scan
- commit author verified as Dashchan2 Release Bot

Source-only change; no local Gradle or APK build was run.