### PR TITLE
Sign Google translator download progress fix

### DIFF
--- a/.github/workflows/sign-google-translator-addon.yml
+++ b/.github/workflows/sign-google-translator-addon.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           repository: andrewpozdnakov7-jpg/Slooop_Addons
-          ref: 63398ac1788964ea43467c843464f03f92401e3c
+          ref: 4a1bfe31602a57ba10ac8da894abaed2ee84fef8
           path: source
           persist-credentials: false
 

--- a/.github/workflows/sign-google-translator-addon.yml
+++ b/.github/workflows/sign-google-translator-addon.yml
@@ -19,11 +19,11 @@ concurrency:
 
 env:
   SOURCE_REPOSITORY: andrewpozdnakov7-jpg/Slooop_Addons
-  SOURCE_PR_NUMBER: '4'
+  SOURCE_PR_NUMBER: '5'
   SOURCE_BRANCH: main
-  SOURCE_HEAD_BRANCH: agent/fix-google-translator-r8-registrars
-  SOURCE_HEAD_COMMIT: c16c8ac429ea88a3ffa8591c362e30bbf5c39eef
-  SOURCE_COMMIT: 63398ac1788964ea43467c843464f03f92401e3c
+  SOURCE_HEAD_BRANCH: agent/fix-google-model-download-progress
+  SOURCE_HEAD_COMMIT: 5ee42145c6efa961c01dc3afdef819f08ea10785
+  SOURCE_COMMIT: 4a1bfe31602a57ba10ac8da894abaed2ee84fef8
   EXPECTED_CERT_SHA256: a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba
   EXPECTED_PACKAGE: io.dashchan2.addon.googletranslate
   EXPECTED_VERSION_NAME: 1.0.0


### PR DESCRIPTION
## What changed

Updated the protected Google Translator Add-on signing workflow to the reviewed source fix:

- source PR: `Slooop_Addons#5`
- source head: `5ee42145c6efa961c01dc3afdef819f08ea10785`
- verified merge commit: `4a1bfe31602a57ba10ac8da894abaed2ee84fef8`

The source fix reports real ML Kit language-model download bytes through Android `DownloadManager`.

## Scope

Only `.github/workflows/sign-google-translator-addon.yml` changes. Slooop source, version, update manifests, beta, and F-Droid are unchanged.

## Validation

- `actionlint` passed locally with the repository's documented SC2016 exclusion.
- Source PR identity, branches, head SHA, merge SHA, and verified GitHub merge commit were checked.
- Diff checked for local paths, credentials, tokens, and personal data.