### PR TITLE
Use one source pin for translator signing

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -95,13 +95,22 @@ jobs:
           head_commit = workflow_value("SOURCE_HEAD_COMMIT")
           merge_commit = workflow_value("SOURCE_COMMIT")
 
+          for name, commit in {
+              "SOURCE_HEAD_COMMIT": head_commit,
+              "SOURCE_COMMIT": merge_commit,
+          }.items():
+              if not re.fullmatch(r"[0-9a-f]{40}", commit):
+                  raise SystemExit(f"Invalid protected signing workflow SHA: {name}")
+
           checkout = re.compile(
-              rf"repository:\s*{re.escape(repository)}\s+"
-              rf"ref:\s*{re.escape(merge_commit)}(?:\s|$)",
+              r"repository:\s*\$\{\{\s*env\.SOURCE_REPOSITORY\s*\}\}\s+"
+              r"ref:\s*\$\{\{\s*env\.SOURCE_COMMIT\s*\}\}(?:\s|$)",
               re.MULTILINE,
           )
           if not checkout.search(text):
-              raise SystemExit("Add-on checkout is not pinned to SOURCE_COMMIT")
+              raise SystemExit(
+                  "Add-on checkout must use SOURCE_REPOSITORY and SOURCE_COMMIT"
+              )
 
           headers = {
               "Accept": "application/vnd.github+json",

--- a/.github/workflows/sign-google-translator-addon.yml
+++ b/.github/workflows/sign-google-translator-addon.yml
@@ -1,6 +1,6 @@
 name: Build and Sign Google Translator Add-on
 
-run-name: Build and sign Google Translator Add-on from Slooop_Addons 63398ac1
+run-name: Build and sign Google Translator Add-on
 
 on:
   workflow_dispatch:
@@ -81,8 +81,8 @@ jobs:
       - name: Check out exact add-on source
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
-          repository: andrewpozdnakov7-jpg/Slooop_Addons
-          ref: 4a1bfe31602a57ba10ac8da894abaed2ee84fef8
+          repository: ${{ env.SOURCE_REPOSITORY }}
+          ref: ${{ env.SOURCE_COMMIT }}
           path: source
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- use `SOURCE_REPOSITORY` and `SOURCE_COMMIT` as the only checkout source configuration
- remove the stale source SHA from the workflow run name
- make required provenance CI validate both SHA formats and the env-based checkout wiring

## Scope
Only the protected Google Translator add-on signing workflow and its required validation job are changed. Application source, release metadata, beta and F-Droid are untouched.

## Validation
- `actionlint -ignore SC2016` for every workflow
- local provenance structure check
- live GitHub verification of Slooop_Addons PR #5 and merge commit `4a1bfe31602a57ba10ac8da894abaed2ee84fef8`
- `git diff --check`
- focused de-anonymization scan