### PR TITLE
Publish Slooop 3.2.27 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,14 +5,14 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.25",
-			"code": 11050,
+			"name": "3.2.27",
+			"code": 11070,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 44610497,
-			"sha256sum": "78e222eede37ae8a669276bb119ee9f06c707441776769ea4d7985ef36a2c472",
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.25/Slooop-3.2.25-11050-ffmpeg8-all-abi-signed.apk",
+			"length": 40263379,
+			"sha256sum": "468a651aa1109e82fefab7557ae48c5599487d4ecf220ee3e582638068d6a5e9",
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.27/Slooop-3.2.27-11070-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## Summary

Publishes the verified stable update manifest for Slooop 3.2.27 (11070).

## Verified artifact

- APK: `Slooop-3.2.27-11070-ffmpeg8-all-abi-signed.apk`
- Bytes: `40263379`
- SHA-256: `468a651aa1109e82fefab7557ae48c5599487d4ecf220ee3e582638068d6a5e9`
- Certificate SHA-256: `a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba`

This PR changes only `update/data.json`. Beta and F-Droid metadata are untouched.