### PR TITLE
Refresh README for Slooop 3.2.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Русский
 
-Slooop - пользовательское название неофициальной ветки Dashchan_2 для Android 11 и новее. Приложение устанавливается рядом с оригинальным Dashchan, использует пакет `io.dashchan2` и содержит встроенную поддержку Двача, экспериментальный режим чтения 4chan и собственный видеоплеер на FFmpeg.
+Slooop - пользовательское название неофициальной ветки Dashchan_2 для Android 11 и новее. Приложение устанавливается рядом с оригинальным Dashchan, использует пакет `io.dashchan2` и содержит встроенную поддержку Двача, Ежчана, Апачана, Архивача, экспериментальный режим чтения 4chan и собственный видеоплеер на FFmpeg.
 
 ### Скачать
 
@@ -14,31 +14,36 @@ Slooop - пользовательское название неофициаль�
 
 | Компонент | Значение |
 | --- | --- |
-| Текущая версия | `3.2.17`, code `10970` |
+| Текущая версия | `3.2.27`, code `11070` |
 | Android package | `io.dashchan2` |
 | Минимальная версия | API 30 / Android 11 |
 | ABI | `arm64-v8a`, `armeabi-v7a`, `x86` |
 | Видеоплеер | FFmpeg 8.1.2, dav1d 1.5.3 |
 
-Поддержка 2ch/Dvach и нативные библиотеки плеера встроены в основной APK. Отдельные дополнения Двача и WebM для нормальной работы больше не требуются. Старые отдельные дополнения можно удалить после проверки встроенных компонентов.
+Поддержка форумов и нативные библиотеки плеера встроены в основной APK. Отдельные дополнения Двача и WebM для нормальной работы больше не требуются. Старые отдельные дополнения можно удалить после проверки встроенных компонентов.
+
+Офлайн-переводчик Google ML Kit для GitHub-версии устанавливается по желанию отдельным дополнением размером около 50 МБ и не увеличивает основной APK. Языковой пакет также загружается отдельно. Свободные шрифты и готовые фоновые изображения скачиваются из публичного каталога дополнений только по выбору пользователя.
 
 ### Возможности
 
 - просмотр досок, тредов, изображений и видео, избранное и фоновые уведомления об ответах;
 - встроенный Двач с отправкой постов, Passcode, AI-фильтром и лайками/дизлайками на поддерживаемых досках;
-- экспериментальный 4chan только для чтения, выключенный по умолчанию;
+- встроенные Ежчан и Апачан с чтением и отправкой сообщений, Архивач в режиме чтения и экспериментальный 4chan только для чтения;
+- «Мои доски» для объединения досок разных форумов в несколько собственных лент;
+- офлайн-перевод постов через Mozilla Bergamot, отдельное дополнение Google ML Kit или Gemini Nano на поддерживаемых устройствах;
 - FFmpeg-плеер для WebM, MP4, fMP4, MOV, H.264, HEVC, VP8, VP9 и AV1;
-- скорость воспроизведения с сохранением тембра, перемотка двойным нажатием, отдельная громкость видео, настраиваемый жест громкости и режим «картинка в картинке»;
-- галерея с фильтрами, копирование и поиск по изображениям, а также фоновое сохранение медиа;
+- скорость воспроизведения с сохранением тембра, перемотка двойным нажатием, масштабирование видео до 10×, отдельная громкость, настраиваемый жест громкости и режим «картинка в картинке»;
+- галерея с фильтрами, редактор изображений, копирование и поиск по изображениям, а также фоновое сохранение медиа;
 - локальные архивы тредов в HTML и ZIP, встроенный просмотрщик и подключение дополнительных папок;
-- встроенные, загружаемые и пользовательские темы с автоматическим дневным и ночным режимом;
+- встроенные, загружаемые и пользовательские темы, фоновые изображения и автоматический дневной и ночной режим;
 - поиск по настройкам, Predictive Back на Android 13+, масштаб текста, загружаемый каталог свободных шрифтов, OpenDyslexic и импорт TTF/OTF;
 - выбор имени и значка приложения, а также создание собственного ярлыка;
-- стабильный и добровольный beta-каналы обновлений с докачиванием APK.
+- проверка стабильных обновлений с докачиванием APK.
 
 ### Ограничения
 
-- 4chan пока не поддерживает отправку постов и может быть недоступен в отдельных сетях;
+- 4chan и Архивач не поддерживают отправку постов; отдельные форумы могут быть недоступны в некоторых сетях;
+- Google ML Kit доступен только как отдельное дополнение GitHub-версии, а Gemini Nano работает только на поддерживаемых устройствах;
 - Predictive Back и «картинка в картинке» включаются вручную;
 - `targetSdk` равен 37 для совместимости с Android 17; `minSdk` остаётся равен 30.
 
@@ -85,7 +90,7 @@ Dashchan_2 основан на исходном коде Dashchan. Отдель�
 
 ## English
 
-Slooop is the user-facing name of the unofficial Dashchan_2 branch for Android 11 and newer. It installs alongside the original Dashchan under the `io.dashchan2` package and bundles Dvach support, experimental read-only 4chan support, and an FFmpeg-based video player.
+Slooop is the user-facing name of the unofficial Dashchan_2 branch for Android 11 and newer. It installs alongside the original Dashchan under the `io.dashchan2` package and bundles support for Dvach, Ejchan, Apachan, Arhivach, experimental read-only 4chan access, and an FFmpeg-based video player.
 
 ### Download
 
@@ -93,29 +98,34 @@ Stable APKs are published only through [GitHub Releases](https://github.com/andr
 
 | Component | Value |
 | --- | --- |
-| Current version | `3.2.17`, code `10970` |
+| Current version | `3.2.27`, code `11070` |
 | Android package | `io.dashchan2` |
 | Minimum Android | API 30 / Android 11 |
 | ABIs | `arm64-v8a`, `armeabi-v7a`, `x86` |
 | Video player | FFmpeg 8.1.2, dav1d 1.5.3 |
 
-2ch/Dvach support and the native player libraries are bundled into the main APK. Separate Dvach and WebM extensions are no longer required for normal use.
+Forum support and the native player libraries are bundled into the main APK. Separate Dvach and WebM extensions are no longer required for normal use.
+
+The Google ML Kit offline translator for the GitHub build is an optional separate add-on of approximately 50 MB and does not increase the main APK size. Its language pack is downloaded separately as well. Free fonts and ready-made wallpapers are downloaded from the public add-ons catalog only when selected by the user.
 
 ### Highlights
 
 - boards, threads, media gallery, favorites, thread watching, and background reply notifications;
 - built-in Dvach posting, Passcode support, AI filtering, and votes on supported boards;
-- optional experimental read-only 4chan channel;
+- built-in Ejchan and Apachan reading and posting, read-only Arhivach, and experimental read-only 4chan access;
+- My Boards feeds that combine boards from different forums into several custom feeds;
+- offline post translation through Mozilla Bergamot, the separate Google ML Kit add-on, or Gemini Nano on supported devices;
 - FFmpeg playback for WebM, MP4, fMP4, MOV, H.264, HEVC, VP8, VP9, and AV1;
-- pitch-preserving speed control, double-tap seeking, per-video volume, configurable volume gestures, and picture-in-picture;
-- gallery filters, clipboard image copying, reverse-image search, background media saving, and local HTML/ZIP thread archives;
-- bundled, downloadable, and user-imported themes with automatic day and night switching;
+- pitch-preserving speed control, double-tap seeking, video zoom up to 10×, per-video volume, configurable volume gestures, and picture-in-picture;
+- gallery filters, an image editor, clipboard image copying, reverse-image search, background media saving, and local HTML/ZIP thread archives;
+- bundled, downloadable, and user-imported themes, optional wallpapers, and automatic day and night switching;
 - settings search, Predictive Back, text scaling, a downloadable catalog of free fonts, OpenDyslexic, custom TTF/OTF fonts, and configurable app names and icons;
-- stable and opt-in beta update channels with resumable APK downloads.
+- stable update checks with resumable APK downloads.
 
 ### Limitations
 
-- 4chan posting is not implemented and the service may be unreachable on some networks;
+- 4chan and Arhivach posting are not implemented; individual forums may be unreachable on some networks;
+- Google ML Kit is available only as a separate add-on for the GitHub build, while Gemini Nano requires a supported device;
 - Predictive Back and picture-in-picture are opt-in settings;
 - `targetSdk` is 37 for Android 17 compatibility; `minSdk` remains 30.
 


### PR DESCRIPTION
## Summary

- refresh the Russian and English README sections for Slooop 3.2.27 (11070)
- document the current forum support, My Boards, translators, add-ons catalog, media features, and image editor
- clarify that Google ML Kit is an optional separate add-on of approximately 50 MB and remove the obsolete beta-channel claim

## Scope

Documentation only: `README.md`. No application sources, version metadata, changelog, update manifest, releases, beta, F-Droid, GitLab, or Slooop_Addons changes.

## Checks

- branch is based on current `master`
- `git diff --check` passes
- Russian and English sections reviewed for parity
- added lines scanned for local paths, personal data, credentials, tokens, logs, and de-anonymizing information