### PR TITLE
Publish Slooop 3.2.28 update manifest

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,14 +5,14 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.27",
-			"code": 11070,
+			"name": "3.2.28",
+			"code": 11080,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 40263379,
-			"sha256sum": "468a651aa1109e82fefab7557ae48c5599487d4ecf220ee3e582638068d6a5e9",
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.27/Slooop-3.2.27-11070-ffmpeg8-all-abi-signed.apk",
+			"length": 40284070,
+			"sha256sum": "ef8bf602490df654dbff119edfc04b3e9be3b1c3f7a72756c193090007bd3b66",
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.28/Slooop-3.2.28-11080-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## Summary
- update only the stable `update/data.json` entry for Slooop 3.2.28 (11080)
- use the exact public Release asset URL, byte size, SHA-256 and signing certificate fingerprint

## Verified asset
- `Slooop-3.2.28-11080-ffmpeg8-all-abi-signed.apk`
- bytes: `40284070`
- SHA-256: `ef8bf602490df654dbff119edfc04b3e9be3b1c3f7a72756c193090007bd3b66`
- certificate SHA-256: `a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba`