### PR TITLE
Fix extension update and trust dialog bugs

### DIFF
--- a/src/com/mishiranu/dashchan/content/async/ReadUpdateTask.java
+++ b/src/com/mishiranu/dashchan/content/async/ReadUpdateTask.java
@@ -466,7 +466,7 @@ public class ReadUpdateTask extends HttpHolderTask<Void, Pair<ErrorItem, ReadUpd
 			String name = uri.getLastPathSegment();
 			boolean directory = false;
 			for (DataVersion dataVersion : DataVersion.values()) {
-				if (name.equals(dataVersion.fileName)) {
+				if (dataVersion.fileName.equals(name)) {
 					directory = true;
 					break;
 				}
@@ -543,8 +543,9 @@ public class ReadUpdateTask extends HttpHolderTask<Void, Pair<ErrorItem, ReadUpd
 		Chan chan = Chan.getFallback();
 		LinkedHashMap<TargetUri, HashSet<String>> targets = new LinkedHashMap<>();
 		HashMap<TargetUri, String> requestedScheme = new HashMap<>();
-		{
-			Uri uri = Uri.parse(UpdateConfiguration.getLegacyManifestUrl());
+		String legacyManifestUrl = UpdateConfiguration.getLegacyManifestUrl();
+		if (!StringUtils.isEmpty(legacyManifestUrl)) {
+			Uri uri = Uri.parse(legacyManifestUrl);
 			TargetUri targetUri = new TargetUri(uri);
 			HashSet<String> extensionNames = new HashSet<>();
 			extensionNames.add(ChanManager.EXTENSION_NAME_CLIENT);

--- a/src/com/mishiranu/dashchan/ui/ExtensionsTrustLoop.java
+++ b/src/com/mishiranu/dashchan/ui/ExtensionsTrustLoop.java
@@ -63,7 +63,7 @@ public class ExtensionsTrustLoop {
 				if (fingerprints.length() > 0) {
 					fingerprints.append(" /");
 				}
-				for (int i = 0; i < fingerprint.length() / 2; i++) {
+				for (int i = 0; i + 1 < fingerprint.length(); i += 2) {
 					if (fingerprints.length() > 0) {
 						fingerprints.append(' ');
 					}


### PR DESCRIPTION
## Summary

- skip the client update target when the legacy manifest URL is empty, while continuing to process external extension repositories
- make update-target filename detection null-safe
- display the complete extension certificate SHA-256 fingerprint as 32 non-overlapping byte pairs

## Scope

The signature and extension trust verification logic is unchanged. This pull request changes only the update target handling and the human-readable trust dialog formatting.

Fixes #62
Fixes #63