### PR TITLE
Fix F-Droid Fragment Result compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -544,7 +544,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.22.1'
 	implementation 'androidx.activity:activity:1.10.1'
 	implementation 'androidx.core:core:1.16.0'
-	implementation 'androidx.fragment:fragment:1.2.5'
+	implementation 'androidx.fragment:fragment:1.3.6'
 	implementation 'androidx.recyclerview:recyclerview:1.1.0'
 	implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
 	implementation 'androidx.webkit:webkit:1.16.0'


### PR DESCRIPTION
## Summary

- update the direct AndroidX Fragment dependency from 1.2.5 to 1.3.6
- provide the Fragment Result API already used by Apachan post editing in every distribution flavor
- restore F-Droid compilation without relying on a GitHub-only transitive dependency

## Context

This is a prerequisite for the F-Droid validation of #64. No application version, changelog, update manifest, source behavior, or distribution configuration is changed.