### PR TITLE
Update stable manifest for Slooop 3.2.31

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,14 +5,14 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.30",
-			"code": 11100,
+			"name": "3.2.31",
+			"code": 11110,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 40362372,
-			"sha256sum": "d104ddb4ef4bc13591e94da9f8657862e02458544a394adcf5bc0d2b80625aa8",
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.30/Slooop-3.2.30-11100-ffmpeg8-all-abi-signed.apk",
+			"length": 40383007,
+			"sha256sum": "579c491989939054692df65a3627eea1deeb71b4cb94d2830a06da07e4e08a67",
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.31/Slooop-3.2.31-11110-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
## Summary

Update only the stable `update/data.json` entry for the published Slooop 3.2.31 universal APK.

## Verified artifact

- version: 3.2.31 (11110)
- size: 40,383,007 bytes
- SHA-256: `579c491989939054692df65a3627eea1deeb71b4cb94d2830a06da07e4e08a67`
- certificate SHA-256: `a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba`