### PR TITLE
Update stable manifest for Slooop 3.2.33

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,14 +5,14 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.32",
-			"code": 11120,
+			"name": "3.2.33",
+			"code": 11130,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 42641464,
-			"sha256sum": "26b17234729e0c018f859a61057f773a518e5efd9102905379f5a0ef027b8005",
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.32/Slooop-3.2.32-11120-ffmpeg8-all-abi-signed.apk",
+			"length": 42871331,
+			"sha256sum": "ca0e70c78d11a9cf051464951b0385e7f1ef63fba18e89b6fb013448c0ff4316",
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.33/Slooop-3.2.33-11130-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
Updates only the stable `update/data.json` entry to the published Slooop 3.2.33 universal APK.

Recorded from the verified public release asset:
- versionName: 3.2.33
- versionCode: 11130
- exact byte length and SHA-256
- release asset URL
- unchanged signing certificate fingerprint