### PR TITLE
Update stable manifest for Slooop 3.2.34

### DIFF
--- a/update/data.json
+++ b/update/data.json
@@ -5,14 +5,14 @@
 	"client": [
 		{
 			"title": "Release",
-			"name": "3.2.33",
-			"code": 11130,
+			"name": "3.2.34",
+			"code": 11140,
 			"minVersion": 1,
 			"maxVersion": 1,
 			"minSdk": 30,
-			"length": 42871331,
-			"sha256sum": "ca0e70c78d11a9cf051464951b0385e7f1ef63fba18e89b6fb013448c0ff4316",
-			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.33/Slooop-3.2.33-11130-ffmpeg8-all-abi-signed.apk",
+			"length": 42891966,
+			"sha256sum": "0e7938a87d0dbe3defba72f590736af1dd1c01ed2e42dd3fb4bfbd66d8154b8c",
+			"source": "https://github.com/andrewpozdnakov7-jpg/Dashchan_2/releases/download/3.2.34/Slooop-3.2.34-11140-ffmpeg8-all-abi-signed.apk",
 			"fingerprint": "a9fbac6c498f7ad8e7c56849afe43881966bed2ed2bc1dd1c73d0ffe0b9ebeba"
 		}
 	],


### PR DESCRIPTION
Updates only the stable client manifest to Slooop 3.2.34 using the exact URL, byte size, SHA-256, version code, and signing certificate fingerprint of the published universal APK.