### PR TITLE
Fix disabled-forum navigation and nullable UI paths

### DIFF
--- a/src/com/mishiranu/dashchan/ui/DrawerForm.java
+++ b/src/com/mishiranu/dashchan/ui/DrawerForm.java
@@ -343,6 +343,9 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	}
 
 	private void updateConfigurationInternal(String chanName, boolean force) {
+		if (chanName != null && !Preferences.isChanEnabled(chanName)) {
+			chanName = null;
+		}
 		if (!CommonUtils.equals(chanName, this.chanName) || force || menu.isEmpty()) {
 			updateConfigurationInternal(chanName, force, createAdapterSnapshot());
 		}
@@ -350,6 +353,9 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 
 	private void updateConfigurationInternal(String chanName, boolean force,
 			ArrayList<AdapterItem> previousItems) {
+		if (chanName != null && !Preferences.isChanEnabled(chanName)) {
+			chanName = null;
+		}
 		if (!CommonUtils.equals(chanName, this.chanName) || force || menu.isEmpty()) {
 			this.chanName = chanName;
 			Chan chan = Chan.get(chanName);
@@ -1108,7 +1114,7 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 		for (int i = 0; i < favoriteBoards.size(); i++) {
 			FavoritesStorage.FavoriteItem favoriteItem = favoriteBoards.get(i);
 			Chan chan = Chan.get(favoriteItem.chanName);
-			if (chan.name == null) {
+			if (chan.name == null || !Preferences.isChanEnabled(favoriteItem.chanName)) {
 				continue;
 			}
 			if (mergeChans || favoriteItem.chanName.equals(chanName)) {

--- a/src/com/mishiranu/dashchan/ui/DrawerForm.java
+++ b/src/com/mishiranu/dashchan/ui/DrawerForm.java
@@ -1084,10 +1084,11 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 	private void updateListFavorites() {
 		this.favorites.clear();
 		boolean mergeChans = this.mergeChans;
+		boolean showAllFavoriteThreads = mergeChans || chanName == null;
 		FavoritesStorage favoritesStorage = FavoritesStorage.getInstance();
 		ArrayList<FavoritesStorage.FavoriteItem> favoriteBoards = favoritesStorage.getBoards(mergeChans
 				? null : chanName);
-		ArrayList<FavoritesStorage.FavoriteItem> favoriteThreads = favoritesStorage.getThreads(mergeChans
+		ArrayList<FavoritesStorage.FavoriteItem> favoriteThreads = favoritesStorage.getThreads(showAllFavoriteThreads
 				? null : chanName);
 		boolean addSection = true;
 		for (int i = 0; i < favoriteThreads.size(); i++) {
@@ -1096,7 +1097,7 @@ public class DrawerForm extends RecyclerView.Adapter<DrawerForm.ViewHolder> impl
 			if (chan.name == null) {
 				continue;
 			}
-			if (mergeChans || favoriteItem.chanName.equals(chanName)) {
+			if (showAllFavoriteThreads || favoriteItem.chanName.equals(chanName)) {
 				if (addSection) {
 					favorites.add(new ListItem(ListItem.Type.SECTION, SECTION_ACTION_FAVORITES_MENU,
 							ResourceUtils.getResourceId(context, R.attr.iconButtonMore, 0),

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -935,7 +935,21 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	}
 
 	private static boolean isPageEnabled(Page page) {
+		if (page.content == Page.Content.MY_POSTS) {
+			return true;
+		}
 		return Chan.get(page.chanName).name != null && Preferences.isChanEnabled(page.chanName);
+	}
+
+	private static Chan getAnyInstalledChan() {
+		Chan chan = ChanManager.getInstance().getDefaultChan();
+		if (chan == null) {
+			for (Chan installedChan : ChanManager.getInstance().getAllChans()) {
+				chan = installedChan;
+				break;
+			}
+		}
+		return chan;
 	}
 
 	private int findLastEnabledSavedPageIndex() {
@@ -2296,7 +2310,8 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				String chanName = page != null ? page.chanName : null;
 				String boardName = page != null ? page.boardName : null;
 				if (chanName == null) {
-					Chan chan = ChanManager.getInstance().getDefaultChan();
+					Chan chan = content == Page.Content.MY_POSTS
+							? getAnyInstalledChan() : ChanManager.getInstance().getDefaultChan();
 					if (chan != null) {
 						chanName = chan.name;
 						boardName = Preferences.getDefaultBoardName(chan);
@@ -2408,8 +2423,9 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				}
 			}
 			ContentFragment currentFragment = getCurrentFragment();
-			if (currentFragment instanceof PageFragment &&
-					removedChanNames.contains(((PageFragment) currentFragment).getPage().chanName)) {
+			if (currentFragment instanceof PageFragment
+					&& ((PageFragment) currentFragment).getPage().content != Page.Content.MY_POSTS
+					&& removedChanNames.contains(((PageFragment) currentFragment).getPage().chanName)) {
 				PageFragment pageFragment = (PageFragment) currentFragment;
 				if (!unavailableChanNames.contains(pageFragment.getPage().chanName) && currentPageItem != null) {
 					preservedPageItems.add(currentPageItem.toSaved(getSupportFragmentManager(), pageFragment));

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -2246,8 +2246,10 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				String boardName = page != null ? page.boardName : null;
 				if (chanName == null) {
 					Chan chan = ChanManager.getInstance().getDefaultChan();
-					chanName = chan.name;
-					boardName = Preferences.getDefaultBoardName(chan);
+					if (chan != null) {
+						chanName = chan.name;
+						boardName = Preferences.getDefaultBoardName(chan);
+					}
 				}
 				if (chanName != null) {
 					navigatePage(content, chanName, boardName, null, null, null, null,

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -1842,8 +1842,14 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 						newBoardName = Preferences.getDefaultBoardName(Chan.get(page.chanName));
 						if (Preferences.isMergeChans() && CommonUtils.equals(page.boardName, newBoardName)) {
 							Chan chan = ChanManager.getInstance().getDefaultChan();
-							newChanName = chan.name;
-							newBoardName = Preferences.getDefaultBoardName(chan);
+							if (chan != null) {
+								newChanName = chan.name;
+								newBoardName = Preferences.getDefaultBoardName(chan);
+							} else {
+								clearStackAndCurrent();
+								navigateInitial(true);
+								return true;
+							}
 						}
 					}
 					clearStackAndCurrent();

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -309,6 +309,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		}
 
 		ContentFragment currentFragmentFromSaved = null;
+		StackItem currentStackItemFromSaved = null;
 		boolean restoredPagesSession = false;
 		if (savedInstanceState == null) {
 			File file = getSavedPagesFile();
@@ -326,6 +327,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				try {
 					StackItem stackItem = AndroidUtils.getParcelable(pagesState,
 							EXTRA_CURRENT_FRAGMENT, StackItem.class);
+					currentStackItemFromSaved = stackItem;
 					currentFragmentFromSaved = stackItem != null ? (ContentFragment) stackItem.create(null) : null;
 				} catch (RuntimeException e) {
 					currentFragmentFromSaved = null;
@@ -366,15 +368,25 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 			}
 		}
 		if (currentFragmentFromSaved != null) {
-			if (currentFragmentFromSaved instanceof PageFragment &&
-					Chan.get(((PageFragment) currentFragmentFromSaved).getPage().chanName).name == null) {
-				currentFragmentFromSaved = null;
-				currentPageItem = null;
+			if (currentFragmentFromSaved instanceof PageFragment) {
+				Page page = ((PageFragment) currentFragmentFromSaved).getPage();
+				if (!isPageEnabled(page)) {
+					if (Chan.get(page.chanName).name != null && currentPageItem != null
+							&& currentStackItemFromSaved != null) {
+						preservedPageItems.add(new SavedPageItem(currentStackItemFromSaved,
+								currentPageItem.createdRealtime, currentPageItem.threadTitle, currentPageItem.allowReturn));
+					}
+					currentFragmentFromSaved = null;
+					currentPageItem = null;
+				}
 			}
-			if (currentFragmentFromSaved == null && !stackPageItems.isEmpty()) {
-				Pair<PageFragment, PageItem> pair = stackPageItems.remove(stackPageItems.size() - 1).create();
-				currentFragmentFromSaved = pair.first;
-				currentPageItem = pair.second;
+			if (currentFragmentFromSaved == null) {
+				SavedPageItem savedPageItem = removeLastEnabledSavedPage();
+				Pair<PageFragment, PageItem> pair = savedPageItem != null ? savedPageItem.create() : null;
+				if (pair != null) {
+					currentFragmentFromSaved = pair.first;
+					currentPageItem = pair.second;
+				}
 			}
 			if (currentFragmentFromSaved != null) {
 				getSupportFragmentManager().beginTransaction()
@@ -922,19 +934,37 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		return REFERENCE_FRAGMENT.getPage();
 	}
 
+	private static boolean isPageEnabled(Page page) {
+		return Chan.get(page.chanName).name != null && Preferences.isChanEnabled(page.chanName);
+	}
+
+	private int findLastEnabledSavedPageIndex() {
+		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
+			if (isPageEnabled(getSavedPage(stackPageItems.get(i)))) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private SavedPageItem getLastEnabledSavedPage() {
+		int index = findLastEnabledSavedPageIndex();
+		return index >= 0 ? stackPageItems.get(index) : null;
+	}
+
 	private int getPagesStackSize(String chanName) {
 		boolean mergeChans = Preferences.isMergeChans();
 		int size = 0;
 		ContentFragment currentFragment = getCurrentFragment();
 		if (currentFragment instanceof PageFragment && currentPageItem != null) {
 			Page page = ((PageFragment) currentFragment).getPage();
-			if (Preferences.isChanEnabled(page.chanName) && (mergeChans || page.chanName.equals(chanName))) {
+			if (isPageEnabled(page) && (mergeChans || page.chanName.equals(chanName))) {
 				size++;
 			}
 		}
 		for (SavedPageItem savedPageItem : stackPageItems) {
 			Page page = getSavedPage(savedPageItem);
-			if (Preferences.isChanEnabled(page.chanName) && (mergeChans || page.chanName.equals(chanName))) {
+			if (isPageEnabled(page) && (mergeChans || page.chanName.equals(chanName))) {
 				size++;
 			}
 		}
@@ -942,13 +972,8 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	}
 
 	private SavedPageItem removeLastEnabledSavedPage() {
-		while (!stackPageItems.isEmpty()) {
-			SavedPageItem savedPageItem = stackPageItems.remove(stackPageItems.size() - 1);
-			if (Preferences.isChanEnabled(getSavedPage(savedPageItem).chanName)) {
-				return savedPageItem;
-			}
-		}
-		return null;
+		int index = findLastEnabledSavedPageIndex();
+		return index >= 0 ? stackPageItems.remove(index) : null;
 	}
 
 	private SavedPageItem prepareTargetPreviousPage(boolean allowForeignChan) {
@@ -959,9 +984,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
 			SavedPageItem savedPageItem = stackPageItems.get(i);
 			Page page = getSavedPage(savedPageItem);
-			if (!Preferences.isChanEnabled(page.chanName)) {
-				stackPageItems.remove(i);
-			} else if (allowAnyChan || mergeChans || page.chanName.equals(chanName)) {
+			if (isPageEnabled(page) && (allowAnyChan || mergeChans || page.chanName.equals(chanName))) {
 				stackPageItems.remove(i);
 				return savedPageItem;
 			}
@@ -979,7 +1002,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		boolean allowAnyChan = currentPageItem != null && allowForeignChan && currentPageItem.allowReturn;
 		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
 			Page page = getSavedPage(stackPageItems.get(i));
-			if (Preferences.isChanEnabled(page.chanName) &&
+			if (isPageEnabled(page) &&
 					(allowAnyChan || mergeChans || page.chanName.equals(chanName))) {
 				return true;
 			}
@@ -996,7 +1019,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		while (iterator.hasNext()) {
 			SavedPageItem savedPageItem = iterator.next();
 			Page page = getSavedPage(savedPageItem);
-			if (mergeChans || page.chanName.equals(chanName)) {
+			if (page.chanName.equals(chanName) || mergeChans && isPageEnabled(page)) {
 				iterator.remove();
 				if (!(page.canDestroyIfNotInStack() || closeOnBack && page.isThreadsOrPosts())) {
 					preservedPageItems.add(savedPageItem);
@@ -1102,7 +1125,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
 			SavedPageItem savedPageItem = stackPageItems.get(i);
 			Page savedPage = getSavedPage(savedPageItem);
-			if (mergeChans || savedPage.chanName.equals(chanName)) {
+			if (savedPage.chanName.equals(chanName) || mergeChans && isPageEnabled(savedPage)) {
 				if (depth++ >= 2 && savedPage.canRemoveFromStackIfDeep()) {
 					stackPageItems.remove(i);
 					if (!savedPage.canDestroyIfNotInStack()) {
@@ -1356,11 +1379,14 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		String chanName;
 		if (currentFragment instanceof PageFragment) {
 			chanName = ((PageFragment) currentFragment).getPage().chanName;
-		} else if (!stackPageItems.isEmpty()) {
-			chanName = getSavedPage(stackPageItems.get(stackPageItems.size() - 1)).chanName;
 		} else {
-			Chan chan = ChanManager.getInstance().getDefaultChan();
-			chanName = chan != null ? chan.name : null;
+			SavedPageItem savedPageItem = getLastEnabledSavedPage();
+			if (savedPageItem != null) {
+				chanName = getSavedPage(savedPageItem).chanName;
+			} else {
+				Chan chan = ChanManager.getInstance().getDefaultChan();
+				chanName = chan != null ? chan.name : null;
+			}
 		}
 		if (currentFragment instanceof PageFragment) {
 			expandedScreen.removeLocker(LOCKER_NON_PAGE);
@@ -1441,7 +1467,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 					}
 				}
 			} else {
-				displayUp = !stackPageItems.isEmpty() || !fragments.isEmpty();
+				displayUp = getLastEnabledSavedPage() != null || !fragments.isEmpty();
 			}
 			drawerToggle.setDrawerIndicatorMode(displayUp ? DrawerToggle.Mode.UP : wideMode
 					? DrawerToggle.Mode.DISABLED : DrawerToggle.Mode.DRAWER);
@@ -1611,7 +1637,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		if (currentFragment instanceof PageFragment) {
 			return hasTargetPreviousPage(true);
 		}
-		return !fragments.isEmpty() || !stackPageItems.isEmpty();
+		return !fragments.isEmpty() || getLastEnabledSavedPage() != null;
 	}
 
 	private void scheduleSystemBackCallbackUpdate() {
@@ -2146,8 +2172,9 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		ContentFragment currentFragment = getCurrentFragment();
 		Page page = currentFragment instanceof PageFragment ? ((PageFragment) currentFragment).getPage() : null;
 		String chanName = page != null ? page.chanName : null;
-		if (chanName == null && !stackPageItems.isEmpty()) {
-			chanName = getSavedPage(stackPageItems.get(stackPageItems.size() - 1)).chanName;
+		if (chanName == null) {
+			SavedPageItem savedPageItem = getLastEnabledSavedPage();
+			chanName = savedPageItem != null ? getSavedPage(savedPageItem).chanName : null;
 		}
 		if (chanName != null) {
 			Chan chan = Chan.get(chanName);
@@ -2162,7 +2189,7 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 			while (iterator.hasNext()) {
 				SavedPageItem savedPageItem = iterator.next();
 				Page savedPage = getSavedPage(savedPageItem);
-				if (mergeChans || savedPage.chanName.equals(chanName)) {
+				if (savedPage.chanName.equals(chanName) || mergeChans && isPageEnabled(savedPage)) {
 					cached |= isCloseAllTarget(savedPage, chanName, boardName, singleBoardMode, singleBoardName);
 					iterator.remove();
 					if (!(savedPage.isThreadsOrPosts() || savedPage.canDestroyIfNotInStack())) {
@@ -2256,8 +2283,9 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 			ContentFragment currentFragment = getCurrentFragment();
 			Page page = currentFragment instanceof PageFragment ? ((PageFragment) currentFragment).getPage() : null;
 			if (page == null || page.content != content) {
-				if (page == null && !stackPageItems.isEmpty()) {
-					page = getSavedPage(stackPageItems.get(stackPageItems.size() - 1));
+				if (page == null) {
+					SavedPageItem savedPageItem = getLastEnabledSavedPage();
+					page = savedPageItem != null ? getSavedPage(savedPageItem) : null;
 				}
 				String chanName = page != null ? page.chanName : null;
 				String boardName = page != null ? page.boardName : null;
@@ -2329,12 +2357,12 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		ContentFragment currentFragment = getCurrentFragment();
 		Page currentPage = currentFragment instanceof PageFragment
 				? ((PageFragment) currentFragment).getPage() : null;
-		DrawerPageKey currentPageKey = currentPage != null && currentPage.isThreadsOrPosts()
-				? new DrawerPageKey(currentPage) : null;
+		DrawerPageKey currentPageKey = currentPage != null && isPageEnabled(currentPage)
+				&& currentPage.isThreadsOrPosts() ? new DrawerPageKey(currentPage) : null;
 		for (SavedPageItem savedPageItem : new ConcatIterable<>(preservedPageItems, stackPageItems)) {
 			Page page = getSavedPage(savedPageItem);
 			DrawerPageKey pageKey = new DrawerPageKey(page);
-			if (page.isThreadsOrPosts() && addedPages.add(pageKey)) {
+			if (isPageEnabled(page) && page.isThreadsOrPosts() && addedPages.add(pageKey)) {
 				drawerPages.add(new DrawerForm.Page(page.chanName, page.boardName, page.threadNumber,
 						savedPageItem.threadTitle, savedPageItem.createdRealtime,
 						pageKey.equals(currentPageKey)));
@@ -2361,18 +2389,29 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				}
 			}
 		} else {
+			HashSet<String> unavailableChanNames = new HashSet<>();
+			for (String chanName : removedChanNames) {
+				if (Chan.get(chanName).name == null) {
+					unavailableChanNames.add(chanName);
+				}
+			}
 			Iterator<SavedPageItem> iterator = new ConcatIterable<>(preservedPageItems, stackPageItems).iterator();
 			while (iterator.hasNext()) {
-				if (removedChanNames.contains(getSavedPage(iterator.next()).chanName)) {
+				if (unavailableChanNames.contains(getSavedPage(iterator.next()).chanName)) {
 					iterator.remove();
 				}
 			}
 			ContentFragment currentFragment = getCurrentFragment();
 			if (currentFragment instanceof PageFragment &&
 					removedChanNames.contains(((PageFragment) currentFragment).getPage().chanName)) {
-				if (!stackPageItems.isEmpty()) {
-					currentPageItem = null;
-					navigateSavedPage(stackPageItems.remove(stackPageItems.size() - 1), true);
+				PageFragment pageFragment = (PageFragment) currentFragment;
+				if (!unavailableChanNames.contains(pageFragment.getPage().chanName) && currentPageItem != null) {
+					preservedPageItems.add(currentPageItem.toSaved(getSupportFragmentManager(), pageFragment));
+				}
+				currentPageItem = null;
+				SavedPageItem savedPageItem = removeLastEnabledSavedPage();
+				if (savedPageItem != null) {
+					navigateSavedPage(savedPageItem, true);
 				} else {
 					navigateInitial(true);
 				}

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -926,28 +926,42 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 		boolean mergeChans = Preferences.isMergeChans();
 		int size = 0;
 		ContentFragment currentFragment = getCurrentFragment();
-		if (currentFragment instanceof PageFragment && currentPageItem != null &&
-				(mergeChans || (((PageFragment) currentFragment).getPage().chanName.equals(chanName)))) {
-			size++;
+		if (currentFragment instanceof PageFragment && currentPageItem != null) {
+			Page page = ((PageFragment) currentFragment).getPage();
+			if (Preferences.isChanEnabled(page.chanName) && (mergeChans || page.chanName.equals(chanName))) {
+				size++;
+			}
 		}
 		for (SavedPageItem savedPageItem : stackPageItems) {
-			if (mergeChans || getSavedPage(savedPageItem).chanName.equals(chanName)) {
+			Page page = getSavedPage(savedPageItem);
+			if (Preferences.isChanEnabled(page.chanName) && (mergeChans || page.chanName.equals(chanName))) {
 				size++;
 			}
 		}
 		return size;
 	}
 
-	private SavedPageItem prepareTargetPreviousPage(boolean allowForeignChan) {
-		if (allowForeignChan && currentPageItem.allowReturn && !stackPageItems.isEmpty()) {
-			return stackPageItems.remove(stackPageItems.size() - 1);
+	private SavedPageItem removeLastEnabledSavedPage() {
+		while (!stackPageItems.isEmpty()) {
+			SavedPageItem savedPageItem = stackPageItems.remove(stackPageItems.size() - 1);
+			if (Preferences.isChanEnabled(getSavedPage(savedPageItem).chanName)) {
+				return savedPageItem;
+			}
 		}
+		return null;
+	}
+
+	private SavedPageItem prepareTargetPreviousPage(boolean allowForeignChan) {
 		ContentFragment currentFragment = getCurrentFragment();
 		String chanName = ((PageFragment) currentFragment).getPage().chanName;
 		boolean mergeChans = Preferences.isMergeChans();
+		boolean allowAnyChan = currentPageItem != null && allowForeignChan && currentPageItem.allowReturn;
 		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
 			SavedPageItem savedPageItem = stackPageItems.get(i);
-			if (mergeChans || getSavedPage(savedPageItem).chanName.equals(chanName)) {
+			Page page = getSavedPage(savedPageItem);
+			if (!Preferences.isChanEnabled(page.chanName)) {
+				stackPageItems.remove(i);
+			} else if (allowAnyChan || mergeChans || page.chanName.equals(chanName)) {
 				stackPageItems.remove(i);
 				return savedPageItem;
 			}
@@ -956,17 +970,17 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	}
 
 	private boolean hasTargetPreviousPage(boolean allowForeignChan) {
-		if (currentPageItem != null && allowForeignChan && currentPageItem.allowReturn && !stackPageItems.isEmpty()) {
-			return true;
-		}
 		ContentFragment currentFragment = getCurrentFragment();
 		if (!(currentFragment instanceof PageFragment)) {
 			return false;
 		}
 		String chanName = ((PageFragment) currentFragment).getPage().chanName;
 		boolean mergeChans = Preferences.isMergeChans();
+		boolean allowAnyChan = currentPageItem != null && allowForeignChan && currentPageItem.allowReturn;
 		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
-			if (mergeChans || getSavedPage(stackPageItems.get(i)).chanName.equals(chanName)) {
+			Page page = getSavedPage(stackPageItems.get(i));
+			if (Preferences.isChanEnabled(page.chanName) &&
+					(allowAnyChan || mergeChans || page.chanName.equals(chanName))) {
 				return true;
 			}
 		}
@@ -1704,9 +1718,12 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 				ContentFragment fragment = (ContentFragment) fragments.remove(fragments.size() - 1).create(null);
 				navigateFragment(fragment, null, true);
 				handled = true;
-			} else if (!stackPageItems.isEmpty()) {
-				navigateSavedPage(stackPageItems.remove(stackPageItems.size() - 1), true);
-				handled = true;
+			} else {
+				SavedPageItem savedPageItem = removeLastEnabledSavedPage();
+				if (savedPageItem != null) {
+					navigateSavedPage(savedPageItem, true);
+					handled = true;
+				}
 			}
 			if (!handled) {
 				if (allowTimeout && SystemClock.elapsedRealtime() - backPressed > 2000) {

--- a/src/com/mishiranu/dashchan/ui/MainActivity.java
+++ b/src/com/mishiranu/dashchan/ui/MainActivity.java
@@ -953,8 +953,12 @@ public class MainActivity extends StateActivity implements DrawerForm.Callback, 
 	}
 
 	private int findLastEnabledSavedPageIndex() {
+		boolean hasEnabledChan = ChanManager.getInstance().getDefaultChan() != null;
 		for (int i = stackPageItems.size() - 1; i >= 0; i--) {
-			if (isPageEnabled(getSavedPage(stackPageItems.get(i)))) {
+			Page page = getSavedPage(stackPageItems.get(i));
+			// Replies remain directly accessible without enabled forums, but must not become an
+			// automatic back-navigation or startup fallback in that state.
+			if (isPageEnabled(page) && (hasEnabledChan || page.content != Page.Content.MY_POSTS)) {
 				return i;
 			}
 		}

--- a/src/com/mishiranu/dashchan/ui/gallery/ListUnit.java
+++ b/src/com/mishiranu/dashchan/ui/gallery/ListUnit.java
@@ -475,9 +475,18 @@ public class ListUnit implements ActionMode.Callback {
 		public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
 			GalleryItem galleryItem = getItem(position);
 			Chan chan = Chan.get(chanName);
-			holder.attachmentInfo.setText(StringUtils
-					.getFileExtension(galleryItem.getFileName(chan)).toUpperCase(Locale.getDefault()) +
-					(galleryItem.size > 0 ? " " + StringUtils.formatFileSize(galleryItem.size, true) : ""));
+			String extension = StringUtils.getFileExtension(galleryItem.getFileName(chan));
+			StringBuilder attachmentInfo = new StringBuilder();
+			if (!StringUtils.isEmpty(extension)) {
+				attachmentInfo.append(extension.toUpperCase(Locale.getDefault()));
+			}
+			if (galleryItem.size > 0) {
+				if (attachmentInfo.length() > 0) {
+					attachmentInfo.append(' ');
+				}
+				attachmentInfo.append(StringUtils.formatFileSize(galleryItem.size, true));
+			}
+			holder.attachmentInfo.setText(attachmentInfo);
 			Uri thumbnailUri = galleryItem.getThumbnailUri(chan);
 			if (thumbnailUri != null) {
 				CacheManager cacheManager = CacheManager.getInstance();

--- a/src/com/mishiranu/dashchan/widget/CommentTextView.java
+++ b/src/com/mishiranu/dashchan/widget/CommentTextView.java
@@ -573,6 +573,10 @@ public class CommentTextView extends TextView {
 
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+			CommentTextView textView = this.textView.get();
+			if (textView == null) {
+				return false;
+			}
 			SelectionMode selectionMode = new SelectionMode() {
 				@Override
 				public boolean isActive() {
@@ -586,7 +590,6 @@ public class CommentTextView extends TextView {
 					onPrepareActionMode(mode, menu);
 				}
 			};
-			CommentTextView textView = this.textView.get();
 			textView.setSelectionMode(selectionMode);
 			currentActionMode = mode;
 			boolean floating = mode.getType() == ActionMode.TYPE_FLOATING;
@@ -598,7 +601,10 @@ public class CommentTextView extends TextView {
 		@Override
 		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
 			if (currentActionMode == mode) {
-				textView.get().onPrepareSelectionMenu(menu);
+				CommentTextView textView = this.textView.get();
+				if (textView != null) {
+					textView.onPrepareSelectionMenu(menu);
+				}
 			}
 			return true;
 		}
@@ -607,13 +613,20 @@ public class CommentTextView extends TextView {
 		public void onDestroyActionMode(ActionMode mode) {
 			if (currentActionMode == mode) {
 				currentActionMode = null;
-				textView.get().setSelectionMode(null);
+				CommentTextView textView = this.textView.get();
+				if (textView != null) {
+					textView.setSelectionMode(null);
+				}
 			}
 		}
 
 		@Override
 		public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-			boolean result = textView.get().onSelectionItemClicked(item.getItemId());
+			CommentTextView textView = this.textView.get();
+			if (textView == null) {
+				return false;
+			}
+			boolean result = textView.onSelectionItemClicked(item.getItemId());
 			if (result) {
 				mode.finish();
 			}

--- a/src/com/mishiranu/dashchan/widget/SortableHelper.java
+++ b/src/com/mishiranu/dashchan/widget/SortableHelper.java
@@ -4,7 +4,6 @@ import android.graphics.Canvas;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
-import java.lang.ref.WeakReference;
 
 public class SortableHelper<VH extends RecyclerView.ViewHolder> extends ItemTouchHelper.Callback {
 	public interface Callback<VH extends RecyclerView.ViewHolder> {
@@ -82,7 +81,7 @@ public class SortableHelper<VH extends RecyclerView.ViewHolder> extends ItemTouc
 		return callback.onDragMove(cast(viewHolder), cast(target));
 	}
 
-	private WeakReference<VH> startViewHolder;
+	private VH startViewHolder;
 
 	@Override
 	public void onSelectedChanged(RecyclerView.ViewHolder viewHolder, int actionState) {
@@ -91,11 +90,16 @@ public class SortableHelper<VH extends RecyclerView.ViewHolder> extends ItemTouc
 		if (actionState == ItemTouchHelper.ACTION_STATE_DRAG) {
 			isDragging = true;
 			VH holder = cast(viewHolder);
-			startViewHolder = new WeakReference<>(holder);
+			startViewHolder = holder;
 			callback.onDragStart(holder);
 		} else if (actionState == ItemTouchHelper.ACTION_STATE_IDLE) {
 			boolean cancelled = !isDragging;
-			callback.onDragFinish(viewHolder != null ? cast(viewHolder) : startViewHolder.get(), cancelled);
+			VH holder = viewHolder != null ? cast(viewHolder) : startViewHolder;
+			isDragging = false;
+			startViewHolder = null;
+			if (holder != null) {
+				callback.onDragFinish(holder, cancelled);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- fixes crashes and nullable UI paths when no forums are enabled
- hides disabled-forum pages and saved boards from automatic navigation while preserving their local state
- keeps favorite threads available and restores saved pages after a forum is re-enabled
- allows the local Replies screen to open without an enabled forum
- prevents Back or startup fallback from automatically restoring Replies when every forum is disabled
- hardens drag completion state

This is technical source preparation for the future F-Droid build of Slooop 3.2.34. It intentionally does not change versionName, versionCode, dependencies, permissions, manifests, changelogs, or release metadata.

## Scope

Only five Java files are changed. The F-Droid source set and dependency boundary are unchanged.
