### PR TITLE
Harden parsing and external input handling

### DIFF
--- a/jni/src/gif/dgif/dgif_lib.c
+++ b/jni/src/gif/dgif/dgif_lib.c
@@ -1099,11 +1099,13 @@ DGifSlurp(GifFileType *GifFile)
 
               sp = &GifFile->SavedImages[GifFile->ImageCount - 1];
               /* Allocate memory for the image */
-              if (sp->ImageDesc.Width < 0 && sp->ImageDesc.Height < 0 &&
-                      sp->ImageDesc.Width > (INT_MAX / sp->ImageDesc.Height)) {
+              if (sp->ImageDesc.Width <= 0 || sp->ImageDesc.Height <= 0 ||
+                      (size_t)sp->ImageDesc.Width >
+                      (size_t)INT_MAX / (size_t)sp->ImageDesc.Height) {
                   return GIF_ERROR;
               }
-              ImageSize = sp->ImageDesc.Width * sp->ImageDesc.Height;
+              ImageSize = (size_t)sp->ImageDesc.Width *
+                      (size_t)sp->ImageDesc.Height;
 
               if (ImageSize > (SIZE_MAX / sizeof(GifPixelType))) {
                   return GIF_ERROR;

--- a/jni/src/gif/gif.c
+++ b/jni/src/gif/gif.c
@@ -4,6 +4,7 @@
 #include <android/bitmap.h>
 #include <gif_lib.h>
 #include <jni.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
@@ -34,8 +35,28 @@ struct ImageData {
 
 #define D_GIF_ERR_CUSTOM 1000
 
+static int getCanvasByteCount(const GifFileType * file, size_t * byteCount) {
+	if (!file || file->SWidth <= 0 || file->SHeight <= 0) {
+		return 0;
+	}
+	size_t width = (size_t) file->SWidth;
+	size_t height = (size_t) file->SHeight;
+	if (width > SIZE_MAX / height) {
+		return 0;
+	}
+	size_t pixels = width * height;
+	if (pixels > SIZE_MAX / sizeof(int)) {
+		return 0;
+	}
+	*byteCount = pixels * sizeof(int);
+	return 1;
+}
+
 jlong init(JNIEnv * env, jstring fileName) {
 	Decoder * decoder = malloc(sizeof(Decoder));
+	if (!decoder) {
+		return 0;
+	}
 	memset(decoder, 0, sizeof(Decoder));
 	decoder->lastIndex = -1;
 	int status = D_GIF_SUCCEEDED;
@@ -50,15 +71,26 @@ jlong init(JNIEnv * env, jstring fileName) {
 			if (status == D_GIF_SUCCEEDED) {
 				status = D_GIF_ERR_CUSTOM;
 			}
-		} else if (file->ImageCount == 0) {
+		} else if (file->ImageCount <= 0) {
 			status = D_GIF_ERR_CUSTOM;
 		} else {
-			status = D_GIF_SUCCEEDED;
+			size_t canvasByteCount;
+			status = getCanvasByteCount(file, &canvasByteCount)
+					? D_GIF_SUCCEEDED : D_GIF_ERR_CUSTOM;
+		}
+	}
+	int when = 0;
+	if (status == D_GIF_SUCCEEDED) {
+		if ((size_t) file->ImageCount > SIZE_MAX / sizeof(ImageData)) {
+			status = D_GIF_ERR_CUSTOM;
+		} else {
+			decoder->datas = malloc(sizeof(ImageData) * (size_t) file->ImageCount);
+			if (!decoder->datas) {
+				status = D_GIF_ERR_CUSTOM;
+			}
 		}
 	}
 	if (status == D_GIF_SUCCEEDED) {
-		int when = 0;
-		decoder->datas = malloc(sizeof(ImageData) * file->ImageCount);
 		for (int i = 0; i < file->ImageCount; i++) {
 			SavedImage * image = &file->SavedImages[i];
 			ImageData * data = &decoder->datas[i];
@@ -83,10 +115,14 @@ jlong init(JNIEnv * env, jstring fileName) {
 		decoder->duration = when;
 		if (!file->SColorMap) {
 			file->SColorMap = GifMakeMapObject(256, NULL);
-			for (int i = 0; i < 256; i++) {
-				file->SColorMap->Colors[i].Red = i;
-				file->SColorMap->Colors[i].Green = i;
-				file->SColorMap->Colors[i].Blue = i;
+			if (!file->SColorMap) {
+				status = D_GIF_ERR_CUSTOM;
+			} else {
+				for (int i = 0; i < 256; i++) {
+					file->SColorMap->Colors[i].Red = i;
+					file->SColorMap->Colors[i].Green = i;
+					file->SColorMap->Colors[i].Blue = i;
+				}
 			}
 		}
 	}
@@ -131,6 +167,10 @@ static int64_t getTime(void) {
 static void drawImage(Decoder * decoder, int index, int * colors) {
 	int width = decoder->file->SWidth;
 	int height = decoder->file->SHeight;
+	size_t canvasByteCount;
+	if (!getCanvasByteCount(decoder->file, &canvasByteCount)) {
+		return;
+	}
 	if (index > 0) {
 		ImageData * data = &decoder->datas[index - 1];
 		if (data->disposalMethod == 2) {
@@ -139,11 +179,17 @@ static void drawImage(Decoder * decoder, int index, int * colors) {
 			int iheight = image->ImageDesc.Height;
 			int ileft = image->ImageDesc.Left;
 			int itop = image->ImageDesc.Top;
-			for (int y = 0; y < iheight && itop + y < height; y++) {
-				memset(colors + width * (itop + y) + ileft, 0, 4 * (ileft + iwidth <= width ? iwidth : width - ileft));
+			if (iwidth > 0 && iheight > 0 && ileft >= 0 && ileft < width && itop >= 0 && itop < height) {
+				size_t clearWidth = (size_t) iwidth < (size_t) (width - ileft)
+						? (size_t) iwidth : (size_t) (width - ileft);
+				int rows = iheight < height - itop ? iheight : height - itop;
+				for (int y = 0; y < rows; y++) {
+					memset(colors + (size_t) width * (size_t) (itop + y) + (size_t) ileft, 0,
+							clearWidth * sizeof(*colors));
+				}
 			}
-		} else if (data->disposalMethod == 3) {
-			memcpy(colors, decoder->previousColors, 4 * width * height);
+		} else if (data->disposalMethod == 3 && decoder->previousColors) {
+			memcpy(colors, decoder->previousColors, canvasByteCount);
 		}
 	}
 	ImageData * data = &decoder->datas[index];
@@ -151,10 +197,12 @@ static void drawImage(Decoder * decoder, int index, int * colors) {
 	if (data->disposalMethod == 3) {
 		if (!decoder->hasPrevious) {
 			if (!decoder->previousColors) {
-				decoder->previousColors = malloc(4 * width * height);
+				decoder->previousColors = malloc(canvasByteCount);
 			}
-			memcpy(decoder->previousColors, colors, 4 * width * height);
-			decoder->hasPrevious = 1;
+			if (decoder->previousColors) {
+				memcpy(decoder->previousColors, colors, canvasByteCount);
+				decoder->hasPrevious = 1;
+			}
 		}
 	} else {
 		decoder->hasPrevious = 0;
@@ -170,14 +218,20 @@ static void drawImage(Decoder * decoder, int index, int * colors) {
 	int iheight = image->ImageDesc.Height;
 	int ileft = image->ImageDesc.Left;
 	int itop = image->ImageDesc.Top;
-	for (int y = 0; y < iheight && itop + y < height; y++) {
-		for (int x = 0; x < iwidth && ileft + x < width; x++) {
-			int colorIndex = source[y * iwidth + x];
+	if (iwidth <= 0 || iheight <= 0 || ileft < 0 || ileft >= width || itop < 0 || itop >= height) {
+		return;
+	}
+	int rows = iheight < height - itop ? iheight : height - itop;
+	int columns = iwidth < width - ileft ? iwidth : width - ileft;
+	for (int y = 0; y < rows; y++) {
+		for (int x = 0; x < columns; x++) {
+			int colorIndex = source[(size_t) y * (size_t) iwidth + (size_t) x];
 			if (colorIndex >= 0 && colorIndex < colorCount && colorIndex != data->transparentIndex) {
 				int red = colorTypes[colorIndex].Red & 0xff;
 				int green = colorTypes[colorIndex].Green & 0xff;
 				int blue = colorTypes[colorIndex].Blue & 0xff;
-				colors[(itop + y) * width + ileft + x] = 0xff000000 | (blue << 16) | (green << 8) | red;
+				colors[(size_t) (itop + y) * (size_t) width + (size_t) ileft + (size_t) x] =
+						0xff000000 | (blue << 16) | (green << 8) | red;
 			}
 		}
 	}
@@ -217,7 +271,12 @@ jint draw(JNIEnv * env, jlong pointer, jobject bitmap) {
 				}
 			} else {
 				decoder->hasPrevious = 0;
-				memset(colors, 0, 4 * decoder->file->SWidth * decoder->file->SHeight);
+				size_t canvasByteCount;
+				if (!getCanvasByteCount(decoder->file, &canvasByteCount)) {
+					AndroidBitmap_unlockPixels(env, bitmap);
+					return -1;
+				}
+				memset(colors, 0, canvasByteCount);
 				for (int i = 0; i <= index; i++) {
 					drawImage(decoder, i, colors);
 				}

--- a/jni/src/player/native.c
+++ b/jni/src/player/native.c
@@ -72,7 +72,7 @@ void JCALL(stopAudio)(UNUSED JNIEnv * env, UNUSED jobject this, jlong pointer) {
 }
 
 void JCALL(setPlaying)(UNUSED JNIEnv * env, UNUSED jobject this, jlong pointer, jboolean playing) {
-	setPlaying(pointer, playing);
+	playerSetPlaying(pointer, playing);
 }
 
 void JCALL(requestSurface)(JNIEnv * env, UNUSED jobject this,

--- a/jni/src/player/player.c
+++ b/jni/src/player/player.c
@@ -563,8 +563,7 @@ void setPlaybackSpeed(jlong pointer, jint speed) {
 	}
 }
 
-void playerSetPlaying(jlong pointer, jboolean playing) {
-	Player * player = POINTER_CAST(pointer);
+void playerApplyPlaying(Player * player, int playing) {
 	playing = !!playing;
 	if (player->play.playing != playing) {
 		diagnosticsLog("player=%u playing=%d", player->meta.diagnosticsId, playing);
@@ -602,6 +601,10 @@ void playerSetPlaying(jlong pointer, jboolean playing) {
 			pthread_mutex_unlock(&player->audio.sleepBufferMutex);
 		}
 	}
+}
+
+void playerSetPlaying(jlong pointer, jboolean playing) {
+	playerApplyPlaying(POINTER_CAST(pointer), playing);
 }
 
 static jstring newUtfStringSafe(JNIEnv * env, char * string) {

--- a/jni/src/player/player.c
+++ b/jni/src/player/player.c
@@ -563,7 +563,7 @@ void setPlaybackSpeed(jlong pointer, jint speed) {
 	}
 }
 
-void setPlaying(jlong pointer, jboolean playing) {
+void playerSetPlaying(jlong pointer, jboolean playing) {
 	Player * player = POINTER_CAST(pointer);
 	playing = !!playing;
 	if (player->play.playing != playing) {

--- a/jni/src/player/player.h
+++ b/jni/src/player/player.h
@@ -23,7 +23,7 @@ void setPlaybackSpeed(jlong, jint);
 jboolean setVolume(jlong, jint, jint);
 jboolean setMuted(jlong, jboolean);
 void stopAudio(jlong);
-void setPlaying(jlong, jboolean);
+void playerSetPlaying(jlong, jboolean);
 void requestSurface(JNIEnv *, jlong, jobject, jlong, jint, jint);
 void setSurfaceSize(jlong, jint, jint);
 

--- a/jni/src/player/player_audio.c
+++ b/jni/src/player/player_audio.c
@@ -428,8 +428,8 @@ static int drainTempoProcessor(Player * player, TempoProcessor * processor,
 		int64_t position = startPosition >= 0
 				? startPosition + av_rescale(*outputSamples, speed, sampleRate) : -1;
 		*outputSamples += samples;
-		int64_t divider = av_get_bytes_per_sample(AV_SAMPLE_FMT_S16) * channels *
-				(int64_t) getPlaybackSampleRateForSpeed(sampleRate, speed);
+		int64_t divider = (int64_t) av_get_bytes_per_sample(AV_SAMPLE_FMT_S16) * channels *
+				getPlaybackSampleRateForSpeed(sampleRate, speed);
 		int frameSize = av_get_bytes_per_sample(AV_SAMPLE_FMT_S16) * channels;
 		if (!queueDecodedAudio(player, buffer, size, frameSize,
 				position, divider, silentAudioLength)) {
@@ -629,8 +629,8 @@ void * playerAudioDecodeThread(void * data) {
 					tempoProcessorFree(&tempoProcessor);
 					tempoStartPosition = -1;
 					tempoOutputSamples = 0;
-					int64_t divider = av_get_bytes_per_sample(dstFormat) * dstChannels *
-							(int64_t) getPlaybackSampleRateForSpeed(dstSampleRate, playbackSpeed);
+					int64_t divider = (int64_t) av_get_bytes_per_sample(dstFormat) * dstChannels *
+							getPlaybackSampleRateForSpeed(dstSampleRate, playbackSpeed);
 					int frameSize = av_get_bytes_per_sample(dstFormat) * dstChannels;
 					if (queueDecodedAudio(player, dstData[0], size, frameSize,
 							position, divider, &silentAudioLength)) {
@@ -639,7 +639,7 @@ void * playerAudioDecodeThread(void * data) {
 					}
 				}
 #else
-				int64_t divider = av_get_bytes_per_sample(dstFormat) * dstChannels * (int64_t) dstSampleRate;
+				int64_t divider = (int64_t) av_get_bytes_per_sample(dstFormat) * dstChannels * dstSampleRate;
 				int frameSize = av_get_bytes_per_sample(dstFormat) * dstChannels;
 				if (queueDecodedAudio(player, dstData[0], size, frameSize,
 						position, divider, &silentAudioLength)) {

--- a/jni/src/player/player_internal.h
+++ b/jni/src/player/player_internal.h
@@ -300,6 +300,7 @@ struct ScaleHolder {
 JavaVM * playerGetJavaVM(void);
 int playerGetSkipFlag(int * flag);
 void playerSetSkipFlag(int * flag, int value);
+void playerApplyPlaying(Player * player, int playing);
 void playerSetDiagnosticsAudioStage(Player * player, int stage);
 void playerSetDiagnosticsMediaCodecStage(Player * player, int stage, int64_t framePosition);
 Bridge * playerObtainBridge(Player * player, JNIEnv * env);

--- a/jni/src/player/player_video_mediacodec.c
+++ b/jni/src/player/player_video_mediacodec.c
@@ -554,7 +554,7 @@ void playerVideoApplyPendingSurface(Player * player, JNIEnv * env) {
 	int64_t startedAt = getTime();
 	int wasPlaying = player->play.playing;
 	if (wasPlaying) {
-		setPlaying((jlong) (long) player, 0);
+		playerSetPlaying((jlong) (long) player, 0);
 	}
 	int64_t position = getPosition((jlong) (long) player);
 	diagnosticsLog("player=%u surface_apply_started generation=%" PRId64

--- a/jni/src/player/player_video_mediacodec.c
+++ b/jni/src/player/player_video_mediacodec.c
@@ -554,7 +554,7 @@ void playerVideoApplyPendingSurface(Player * player, JNIEnv * env) {
 	int64_t startedAt = getTime();
 	int wasPlaying = player->play.playing;
 	if (wasPlaying) {
-		playerSetPlaying((jlong) (long) player, 0);
+		playerApplyPlaying(player, 0);
 	}
 	int64_t position = getPosition((jlong) (long) player);
 	diagnosticsLog("player=%u surface_apply_started generation=%" PRId64

--- a/jni/src/player/player_video_software.c
+++ b/jni/src/player/player_video_software.c
@@ -229,10 +229,11 @@ static void drawWindow(Player * player, uint8_t * buffer, int width, int height,
 				} else {
 					int bytesPerPixel = getBytesPerPixel(player->video.format);
 					if (bytesPerPixel > 0) {
+						size_t rowBytes = (size_t) bytesPerPixel * (size_t) width;
 						for (int i = 0; i < height; i++) {
-							memcpy(to, buffer, bytesPerPixel * width);
-							to += bytesPerPixel * canvas.stride;
-							buffer += bytesPerPixel * width;
+							memcpy(to, buffer, rowBytes);
+							to += (size_t) bytesPerPixel * (size_t) canvas.stride;
+							buffer += rowBytes;
 						}
 					}
 				}
@@ -396,9 +397,10 @@ static void extendScaleHolder(ScaleHolder * scaleHolder, int bufferSize, int wid
 		}
 		scaleHolder->scaleBuffer = av_malloc(bufferSize);
 	}
+	size_t lumaSize = (size_t) width * (size_t) height;
 	scaleHolder->scaleData[0] = scaleHolder->scaleBuffer;
-	scaleHolder->scaleData[1] = isYUV ? scaleHolder->scaleBuffer + width * height + width * height / 4 : NULL;
-	scaleHolder->scaleData[2] = isYUV ? scaleHolder->scaleBuffer + width * height : NULL;
+	scaleHolder->scaleData[1] = isYUV ? scaleHolder->scaleBuffer + lumaSize + lumaSize / 4 : NULL;
+	scaleHolder->scaleData[2] = isYUV ? scaleHolder->scaleBuffer + lumaSize : NULL;
 	scaleHolder->scaleData[3] = NULL;
 	scaleHolder->scaleLinesize[0] = bytesPerPixel * width;
 	scaleHolder->scaleLinesize[1] = isYUV ? width / 2 : 0;
@@ -762,18 +764,20 @@ int playerVideoSoftwarePrepareOutputLocked(Player * player) {
 		player->video.lastBuffer.height = height;
 		if (videoFormat == AV_PIX_FMT_RGBA) {
 			// RGBA_8888 "black" buffer
-			int count = 4 * width * height;
+			int count = videoBufferSize;
 			memset(player->video.lastBuffer.data, 0x00, count);
 			for (int i = 3; i < count; i += 4) {
 				player->video.lastBuffer.data[i] = 0xff;
 			}
 		} else if (videoFormat == AV_PIX_FMT_RGB565LE) {
 			// RGB_565 "black" buffer
-			memset(player->video.lastBuffer.data, 0x00, 2 * width * height);
+			memset(player->video.lastBuffer.data, 0x00, (size_t) videoBufferSize);
 		} else if (videoFormat == AV_PIX_FMT_YUV420P) {
 			// YV12 "black" buffer
-			memset(player->video.lastBuffer.data, 0, width * height);
-			memset(player->video.lastBuffer.data + width * height, 0x7f, width * height / 2);
+			size_t lumaSize = (size_t) width * (size_t) height;
+			memset(player->video.lastBuffer.data, 0, lumaSize);
+			memset(player->video.lastBuffer.data + lumaSize, 0x7f,
+					(size_t) videoBufferSize - lumaSize);
 		}
 		pthread_cond_broadcast(&player->video.sleepCond);
 		diagnosticsLog("player=%u software_output source=%dx%d surface=%dx%d"

--- a/src/chan/http/HttpClient.java
+++ b/src/chan/http/HttpClient.java
@@ -1,6 +1,5 @@
 package chan.http;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
 import android.os.SystemClock;
@@ -40,7 +39,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,32 +54,14 @@ import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipException;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509TrustManager;
 import org.brotli.dec.BrotliInputStream;
 
 public class HttpClient {
 	private static final HashMap<String, String> SHORT_RESPONSE_MESSAGES = new HashMap<>();
-
-	private static final HostnameVerifier UNSAFE_HOSTNAME_VERIFIER = (hostname, session) -> true;
-
-	@SuppressLint("TrustAllX509TrustManager")
-	private static final X509TrustManager UNSAFE_TRUST_MANAGER = new X509TrustManager() {
-		@Override
-		public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-		@Override
-		public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-
-		@Override
-		public X509Certificate[] getAcceptedIssuers() {
-			return null;
-		}
-	};
 
 	static final int HTTP_TEMPORARY_REDIRECT = 307;
 
@@ -231,7 +211,6 @@ public class HttpClient {
 
 	private boolean ssl3Disabled = false;
 	private SSLSocketFactory sslSocketFactory;
-	private SSLSocketFactory unsafeSslSocketFactory;
 
 	static final class InterruptedHttpException extends IOException {
 		public HttpException toHttp() {
@@ -280,24 +259,12 @@ public class HttpClient {
 				sslSocketFactory = new SSLSocketFactoryWrapper(sslSocketFactory,
 						socket -> new HandshakeSSLSocket(socket, handshakeSessions.get()));
 			}
-			if (verifyCertificate) {
-				return sslSocketFactory;
-			}
-			if (unsafeSslSocketFactory == null) {
-				try {
-					SSLContext sslContext = SSLContext.getInstance("TLS");
-					sslContext.init(null, new X509TrustManager[] {UNSAFE_TRUST_MANAGER}, null);
-					unsafeSslSocketFactory = sslContext.getSocketFactory();
-				} catch (Exception e) {
-					unsafeSslSocketFactory = sslSocketFactory;
-				}
-			}
-			return unsafeSslSocketFactory;
+			return sslSocketFactory;
 		}
 	}
 
 	HostnameVerifier getHostnameVerifier(boolean verifyCertificate) {
-		return verifyCertificate ? HttpsURLConnection.getDefaultHostnameVerifier() : UNSAFE_HOSTNAME_VERIFIER;
+		return HttpsURLConnection.getDefaultHostnameVerifier();
 	}
 
 	HttpResponse execute(HttpSession session, HttpRequest request) throws HttpException {
@@ -604,7 +571,6 @@ public class HttpClient {
 							ssl3Disabled = true;
 							// Fix https://code.google.com/p/android/issues/detail?id=78187
 							sslSocketFactory = new SSLSocketFactoryWrapper(sslSocketFactory, NoSSLv3SSLSocket::new);
-							unsafeSslSocketFactory = null;
 						}
 					}
 					if (session.nextAttempt()) {

--- a/src/com/mishiranu/dashchan/chan/dvach/DvachChanPerformer.java
+++ b/src/com/mishiranu/dashchan/chan/dvach/DvachChanPerformer.java
@@ -28,13 +28,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.text.DateFormatSymbols;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -991,10 +992,68 @@ public class DvachChanPerformer extends ChanPerformer {
 	}
 
 	private static final Pattern PATTERN_TAG = Pattern.compile("(.*) /([^/]*)/");
-	private static final Pattern PATTERN_BAN = Pattern.compile("[^ ]*?: (\\d+)\\. .*: (.*(?=//![a-z]+\\.)|.*(?=[А-Я][а-я]{2} [А-Я][а-я]{2} \\d{2} (?:\\d{2}:?){3} \\d{4}$)|.*$)(?:.*?[а-я] )?([А-Я].*|)");
 
 	private static final ThreadLocal<SimpleDateFormat> DATE_FORMAT_BAN =
 			ThreadLocal.withInitial(DvachChanPerformer::createBanDateFormat);
+
+	private static class BanDetails {
+		public final String id;
+		public final String message;
+		public final long expireDate;
+
+		public BanDetails(String id, String message, long expireDate) {
+			this.id = id;
+			this.message = message;
+			this.expireDate = expireDate;
+		}
+	}
+
+	private static boolean isAsciiDigits(String value, int start, int end) {
+		if (start >= end) return false;
+		for (int i = start; i < end; i++) {
+			char c = value.charAt(i);
+			if (c < '0' || c > '9') return false;
+		}
+		return true;
+	}
+
+	private static BanDetails parseBanDetails(String reason) {
+		if (StringUtils.isEmpty(reason)) return null;
+		int idStart = reason.indexOf(": ");
+		if (idStart < 0) return null;
+		idStart += 2;
+		int idEnd = reason.indexOf(". ", idStart);
+		if (idEnd < 0 || !isAsciiDigits(reason, idStart, idEnd)) return null;
+		int messageStart = reason.indexOf(": ", idEnd + 2);
+		if (messageStart < 0) return null;
+		messageStart += 2;
+		String details = reason.substring(messageStart).trim();
+		int marker = details.indexOf("//!");
+		if (marker >= 0) {
+			int markerEnd = details.indexOf('.', marker + 3);
+			if (markerEnd > marker + 3) details = details.substring(0, marker).trim();
+		}
+		long expireDate = 0L;
+		int earliestDateStart = Math.max(0, details.length() - 32);
+		for (int start = earliestDateStart; start < details.length(); start++) {
+			String candidate = details.substring(start);
+			ParsePosition position = new ParsePosition(0);
+			Date date = DATE_FORMAT_BAN.get().parse(candidate, position);
+			if (date != null && position.getIndex() == candidate.length()) {
+				expireDate = date.getTime();
+				int messageEnd = start;
+				if (start >= 4 && details.charAt(start - 1) == ' ' &&
+						Character.isUpperCase(details.charAt(start - 4)) &&
+						Character.isLowerCase(details.charAt(start - 3)) &&
+						Character.isLowerCase(details.charAt(start - 2))) {
+					messageEnd = start - 4;
+				}
+				details = details.substring(0, messageEnd).trim();
+				break;
+			}
+		}
+		return new BanDetails(reason.substring(idStart, idEnd), details, expireDate);
+	}
 
 	@SuppressLint("SimpleDateFormat")
 	private static SimpleDateFormat createBanDateFormat() {
@@ -1174,23 +1233,12 @@ public class DvachChanPerformer extends ChanPerformer {
 		}
 		if (errorType == ApiException.SEND_ERROR_BANNED) {
 			ApiException.BanExtra banExtra = new ApiException.BanExtra();
-			Matcher matcher = PATTERN_BAN.matcher(reason);
-			if(matcher.find()) {
-				String banId = StringUtils.emptyIfNull(matcher.group(1));
-				banExtra.setId(banId);
-				String banMessage = StringUtils.emptyIfNull(matcher.group(2));
-				banExtra.setMessage(banMessage);
-				String banExpireDate = StringUtils.emptyIfNull(matcher.group(3));
-				if (!StringUtils.isEmpty(banExpireDate)) {
-					try {
-						long date = Objects.requireNonNull(DATE_FORMAT_BAN.get().parse(banExpireDate)).getTime();
-						banExtra.setExpireDate(date);
-					} catch (java.text.ParseException e) {
-						// Ignore exception
-					}
-				}
-			}
-			else {
+			BanDetails details = parseBanDetails(reason);
+			if (details != null) {
+				banExtra.setId(details.id);
+				banExtra.setMessage(details.message);
+				if (details.expireDate > 0L) banExtra.setExpireDate(details.expireDate);
+			} else {
 				banExtra.setMessage(reason);
 			}
 			extra = banExtra;

--- a/src/com/mishiranu/dashchan/chan/dvach/DvachModelMapper.java
+++ b/src/com/mishiranu/dashchan/chan/dvach/DvachModelMapper.java
@@ -30,8 +30,33 @@ public class DvachModelMapper {
 	private static final Pattern PATTERN_BADGE = Pattern.compile("<img.+?src=\"(.+?)\".+?(?:title=\"(.+?)\")?.+?/?>");
 	private static final Pattern PATTERN_CODE = Pattern.compile("\\[code(?:\\s+lang=.+?)?](?:<br ?/?>)*(.+?)" +
 			"(?:<br ?/?>)*\\[/code]", Pattern.CASE_INSENSITIVE);
-	private static final Pattern PATTERN_HASHLINK = Pattern.compile("<a [^<>]*class=\"hashlink\"[^<>]*>");
-	private static final Pattern PATTERN_HASHLINK_TITLE = Pattern.compile("title=\"(.*?)\"");
+
+	private static String replaceHashLinks(String comment, DvachChanLocator locator, String boardName) {
+		StringBuilder result = null;
+		int copyFrom = 0;
+		int searchFrom = 0;
+		while (true) {
+			int tagStart = comment.indexOf("<a ", searchFrom);
+			if (tagStart < 0) break;
+			int tagEnd = comment.indexOf('>', tagStart + 3);
+			if (tagEnd < 0) break;
+			String tag = comment.substring(tagStart, tagEnd + 1);
+			Element link = Jsoup.parseBodyFragment(tag + "</a>").selectFirst("a.hashlink[title]");
+			if (link != null) {
+				String title = link.attr("title");
+				if (!title.isEmpty()) {
+					Uri uri = locator.createCatalogSearchUri(boardName, title);
+					String encodedUri = uri.toString().replace("&", "&amp;").replace("\"", "&quot;");
+					if (result == null) result = new StringBuilder(comment.length());
+					result.append(comment, copyFrom, tagStart).append("<a href=\"").append(encodedUri).append("\">");
+					copyFrom = tagEnd + 1;
+				}
+			}
+			searchFrom = tagEnd + 1;
+		}
+		if (result == null) return comment;
+		return result.append(comment, copyFrom, comment.length()).toString();
+	}
 
 	public static class Extra {
 		public String tags;
@@ -293,20 +318,7 @@ public class DvachModelMapper {
 						comment = comment.replace("&#47;", "/");
 					}
 					if (comment.contains("\"hashlink\"")) {
-						comment = StringUtils.replaceAll(comment, PATTERN_HASHLINK, matcher -> {
-							String title = null;
-							Matcher matcher2 = PATTERN_HASHLINK_TITLE.matcher(matcher.group());
-							if (matcher2.find()) {
-								title = matcher2.group(1);
-							}
-							if (title != null) {
-								Uri uri = locator.createCatalogSearchUri(boardName, title);
-								String encodedUri = uri.toString().replace("&", "&amp;").replace("\"", "&quot;");
-								return "<a href=\"" + encodedUri + "\">";
-							} else {
-								return matcher.group();
-							}
-						});
+						comment = replaceHashLinks(comment, locator, boardName);
 					}
 					if ("pr".equals(boardName) && comment.contains("[code")) {
 						comment = PATTERN_CODE.matcher(comment).replaceAll("<fakecode>$1</fakecode>");

--- a/src/com/mishiranu/dashchan/chan/endchan/EndchanModelMapper.java
+++ b/src/com/mishiranu/dashchan/chan/endchan/EndchanModelMapper.java
@@ -76,9 +76,61 @@ public final class EndchanModelMapper {
 		return attachment;
 	}
 
-	private static final Pattern PATTERN_BROKEN_LINK = Pattern.compile("(<a [^>]*?href=\"/[^/]+/res/)"
-			+ "(\\d+)(\\.html#\\2\")");
 	private static final Pattern PATTERN_COLORED_TEXT = Pattern.compile("<span class=\"(\\w+)Text\">");
+
+	private static boolean isAsciiDigits(String value, int start, int end) {
+		if (start >= end) return false;
+		for (int i = start; i < end; i++) {
+			char c = value.charAt(i);
+			if (c < '0' || c > '9') return false;
+		}
+		return true;
+	}
+
+	private static String fixQuoteLinks(String comment, String threadNumber) {
+		StringBuilder result = null;
+		int copyFrom = 0;
+		int searchFrom = 0;
+		while (true) {
+			int tagStart = comment.indexOf("<a ", searchFrom);
+			if (tagStart < 0) break;
+			int tagEnd = comment.indexOf('>', tagStart + 3);
+			if (tagEnd < 0) break;
+			int afterTag = tagEnd + 1;
+			if (comment.startsWith("<a class=\"quoteLink\"", tagStart) &&
+					comment.startsWith("&gt&gt", afterTag)) {
+				if (result == null) result = new StringBuilder(comment.length() + 2);
+				result.append(comment, copyFrom, afterTag).append("&gt;&gt;");
+				copyFrom = afterTag + 6;
+				searchFrom = copyFrom;
+				continue;
+			}
+			if (threadNumber != null) {
+				int hrefStart = comment.indexOf("href=\"", tagStart + 3);
+				if (hrefStart >= 0 && hrefStart < tagEnd) {
+					hrefStart += 6;
+					int hrefEnd = comment.indexOf('\"', hrefStart);
+					int res = comment.indexOf("/res/", hrefStart);
+					if (hrefEnd >= 0 && hrefEnd <= tagEnd && res > hrefStart && res < hrefEnd &&
+							comment.charAt(hrefStart) == '/' && comment.indexOf('/', hrefStart + 1) == res) {
+						int numberStart = res + 5;
+						int separator = comment.indexOf(".html#", numberStart);
+						if (separator > numberStart && separator < hrefEnd &&
+								isAsciiDigits(comment, numberStart, separator) &&
+								comment.regionMatches(separator + 6, comment, numberStart, separator - numberStart) &&
+								separator + 6 + separator - numberStart == hrefEnd) {
+							if (result == null) result = new StringBuilder(comment.length());
+							result.append(comment, copyFrom, numberStart).append(threadNumber);
+							copyFrom = separator;
+						}
+					}
+				}
+			}
+			searchFrom = tagEnd + 1;
+		}
+		if (result == null) return comment;
+		return result.append(comment, copyFrom, comment.length()).toString();
+	}
 
 	private static long parseTimestamp(String value) throws JSONException {
 		try {
@@ -147,11 +199,7 @@ public final class EndchanModelMapper {
 		}
 		String comment = CommonUtils.getJsonString(jsonObject, "markdown");
 		if (!StringUtils.isEmpty(comment)) {
-			comment = comment.replaceAll("(<a class=\"quoteLink\".*?>)&gt&gt", "$1&gt;&gt;");
-			String fixedThreadNumber = threadNumber;
-			comment = StringUtils.replaceAll(comment, PATTERN_BROKEN_LINK,
-					matcher -> matcher.group(1) + (fixedThreadNumber != null ? fixedThreadNumber : matcher.group(2))
-							+ matcher.group(3));
+			comment = fixQuoteLinks(comment, threadNumber);
 			comment = StringUtils.replaceAll(comment, PATTERN_COLORED_TEXT, matcher -> {
 				String color = matcher.group(1);
 				switch (color) {

--- a/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -504,7 +504,18 @@ public class FourchanChanPerformer extends ChanPerformer {
 		return message;
 	}
 
-	private static final Pattern PATTERN_AUTH_MESSAGE = Pattern.compile("<h2.*?>(.*?)<(?:br|/h2)>");
+	private static String readHtmlElementText(String responseText, String selector, boolean stopAtBreak) {
+		if (StringUtils.isEmpty(responseText)) {
+			return null;
+		}
+		Element element = Jsoup.parse(responseText).selectFirst(selector);
+		if (element == null) return null;
+		if (!stopAtBreak) return element.text();
+		String html = element.html();
+		int breakIndex = html.toLowerCase(Locale.US).indexOf("<br");
+		if (breakIndex >= 0) html = html.substring(0, breakIndex);
+		return StringUtils.clearHtml(html);
+	}
 
 	@Override
 	public CheckAuthorizationResult onCheckAuthorization(CheckAuthorizationData data) throws HttpException,
@@ -532,9 +543,8 @@ public class FourchanChanPerformer extends ChanPerformer {
 				.setRedirectHandler(strictUnsafeRedirectHandler)
                 .perform();
 		String responseText = response.readString();
-		Matcher matcher = PATTERN_AUTH_MESSAGE.matcher(responseText);
-		if (matcher.find()) {
-			String message = StringUtils.clearHtml(matcher.group(1));
+		String message = readHtmlElementText(responseText, "h2", true);
+		if (message != null) {
 			if (message.startsWith("Error: ")) {
 				message = message.substring(7);
 			}
@@ -813,7 +823,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 		return prefix + "_" + COOKIE_FOURCHAN_PASS;
 	}
 
-	private static final Pattern PATTERN_POST_ERROR = Pattern.compile("<span id=\"errmsg\".*?>(.*?)</span>");
 	private static final Pattern PATTERN_POST_SUCCESS = Pattern.compile("<!-- thread:(\\d+),no:(\\d+) -->");
 
 	private static final HashSet<String> FORBIDDEN_OPTIONS = new HashSet<>(Arrays.asList("nonoko", "nonokosage"));
@@ -880,43 +889,40 @@ public class FourchanChanPerformer extends ChanPerformer {
 			}
 			return new SendPostResult(threadNumber, postNumber);
 		}
-		matcher = PATTERN_POST_ERROR.matcher(responseText);
-		if (matcher.find()) {
-			String errorMessage = matcher.group(1);
-			if (errorMessage != null) {
-				int errorType = 0;
-				Object extra = null;
-				if (errorMessage.contains("CAPTCHA")) {
-					errorType = ApiException.SEND_ERROR_CAPTCHA;
-				} else if (errorMessage.contains("No text entered")) {
-					errorType = ApiException.SEND_ERROR_EMPTY_COMMENT;
-				} else if (errorMessage.contains("No file selected")) {
-					errorType = ApiException.SEND_ERROR_EMPTY_FILE;
-				} else if (errorMessage.contains("File too large")) {
-					errorType = ApiException.SEND_ERROR_FILE_TOO_BIG;
-				} else if (errorMessage.contains("Field too long")) {
-					errorType = ApiException.SEND_ERROR_FIELD_TOO_LONG;
-				} else if (errorMessage.contains("You cannot reply to this thread anymore")) {
-					errorType = ApiException.SEND_ERROR_CLOSED;
-				} else if (errorMessage.contains("This board doesn't exist")) {
-					errorType = ApiException.SEND_ERROR_NO_BOARD;
-				} else if (errorMessage.contains("Specified thread does not exist")) {
-					errorType = ApiException.SEND_ERROR_NO_THREAD;
-				} else if (errorMessage.contains("You must wait")) {
-					errorType = ApiException.SEND_ERROR_TOO_FAST;
-				} else if (errorMessage.contains("Corrupted file or unsupported file type")) {
-					errorType = ApiException.SEND_ERROR_FILE_NOT_SUPPORTED;
-				} else if (errorMessage.contains("Duplicate file exists")) {
-					errorType = ApiException.SEND_ERROR_FILE_EXISTS;
-				} else if (errorMessage.contains("has been blocked due to abuse") || errorMessage.contains("banned")) {
-					errorType = ApiException.SEND_ERROR_BANNED;
-					extra = readBanExtra(data, data.boardName);
-				} else if (errorMessage.contains("image replies has been reached")) {
-					errorType = ApiException.SEND_ERROR_FILES_LIMIT;
-				}
-				if (errorType != 0) {
-					throw new ApiException(errorType, extra);
-				}
+		String errorMessage = readHtmlElementText(responseText, "span#errmsg", false);
+		if (errorMessage != null) {
+			int errorType = 0;
+			Object extra = null;
+			if (errorMessage.contains("CAPTCHA")) {
+				errorType = ApiException.SEND_ERROR_CAPTCHA;
+			} else if (errorMessage.contains("No text entered")) {
+				errorType = ApiException.SEND_ERROR_EMPTY_COMMENT;
+			} else if (errorMessage.contains("No file selected")) {
+				errorType = ApiException.SEND_ERROR_EMPTY_FILE;
+			} else if (errorMessage.contains("File too large")) {
+				errorType = ApiException.SEND_ERROR_FILE_TOO_BIG;
+			} else if (errorMessage.contains("Field too long")) {
+				errorType = ApiException.SEND_ERROR_FIELD_TOO_LONG;
+			} else if (errorMessage.contains("You cannot reply to this thread anymore")) {
+				errorType = ApiException.SEND_ERROR_CLOSED;
+			} else if (errorMessage.contains("This board doesn't exist")) {
+				errorType = ApiException.SEND_ERROR_NO_BOARD;
+			} else if (errorMessage.contains("Specified thread does not exist")) {
+				errorType = ApiException.SEND_ERROR_NO_THREAD;
+			} else if (errorMessage.contains("You must wait")) {
+				errorType = ApiException.SEND_ERROR_TOO_FAST;
+			} else if (errorMessage.contains("Corrupted file or unsupported file type")) {
+				errorType = ApiException.SEND_ERROR_FILE_NOT_SUPPORTED;
+			} else if (errorMessage.contains("Duplicate file exists")) {
+				errorType = ApiException.SEND_ERROR_FILE_EXISTS;
+			} else if (errorMessage.contains("has been blocked due to abuse") || errorMessage.contains("banned")) {
+				errorType = ApiException.SEND_ERROR_BANNED;
+				extra = readBanExtra(data, data.boardName);
+			} else if (errorMessage.contains("image replies has been reached")) {
+				errorType = ApiException.SEND_ERROR_FILES_LIMIT;
+			}
+			if (errorType != 0) {
+				throw new ApiException(errorType, extra);
 			}
 			CommonUtils.writeLog("4chan send message", errorMessage);
 			throw new ApiException(errorMessage);
@@ -939,29 +945,26 @@ public class FourchanChanPerformer extends ChanPerformer {
 				.setRedirectHandler(strictUnsafeRedirectHandler)
                 .perform()
 				.readString();
-		Matcher matcher = PATTERN_POST_ERROR.matcher(responseText);
-		if (matcher.find()) {
-			String errorMessage = matcher.group(1);
-			if (errorMessage != null) {
-				int errorType = 0;
-				if (errorMessage.contains("Password incorrect")) {
-					errorType = ApiException.DELETE_ERROR_PASSWORD;
-				} else if (errorMessage.contains("You must wait longer before deleting this post")) {
-					errorType = ApiException.DELETE_ERROR_TOO_NEW;
-				} else if (errorMessage.contains("You cannot delete a post this old")) {
-					errorType = ApiException.DELETE_ERROR_TOO_OLD;
-				} else if (errorMessage.contains("Can't find the post")) {
-					errorType = ApiException.DELETE_ERROR_NOT_FOUND;
-				} else if (errorMessage.contains("You cannot delete posts this often")) {
-					errorType = ApiException.DELETE_ERROR_TOO_OFTEN;
-				}
-				if (errorType == ApiException.SEND_ERROR_CAPTCHA) {
-					lastCaptchaPassData = null;
-					lastCaptchaPassCookie = null;
-				}
-				if (errorType != 0) {
-					throw new ApiException(errorType);
-				}
+		String errorMessage = readHtmlElementText(responseText, "span#errmsg", false);
+		if (errorMessage != null) {
+			int errorType = 0;
+			if (errorMessage.contains("Password incorrect")) {
+				errorType = ApiException.DELETE_ERROR_PASSWORD;
+			} else if (errorMessage.contains("You must wait longer before deleting this post")) {
+				errorType = ApiException.DELETE_ERROR_TOO_NEW;
+			} else if (errorMessage.contains("You cannot delete a post this old")) {
+				errorType = ApiException.DELETE_ERROR_TOO_OLD;
+			} else if (errorMessage.contains("Can't find the post")) {
+				errorType = ApiException.DELETE_ERROR_NOT_FOUND;
+			} else if (errorMessage.contains("You cannot delete posts this often")) {
+				errorType = ApiException.DELETE_ERROR_TOO_OFTEN;
+			}
+			if (errorType == ApiException.SEND_ERROR_CAPTCHA) {
+				lastCaptchaPassData = null;
+				lastCaptchaPassCookie = null;
+			}
+			if (errorType != 0) {
+				throw new ApiException(errorType);
 			}
 			errorMessage = removeErrorFromMessage(errorMessage);
 			CommonUtils.writeLog("4chan delete message", errorMessage);
@@ -969,8 +972,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 		}
 		return null;
 	}
-
-	private static final Pattern PATTERN_REPORT_MESSAGE = Pattern.compile("<font.*?>(.*?)<(?:br|/font)>");
 
 	@Override
 	public SendReportPostsResult onSendReportPosts(SendReportPostsData data) throws HttpException, ApiException,
@@ -1004,9 +1005,8 @@ public class FourchanChanPerformer extends ChanPerformer {
                     .perform();
 			handleFourchanPass(response, data.boardName);
 			String responseText = response.readString();
-			Matcher matcher = PATTERN_REPORT_MESSAGE.matcher(responseText);
-			if (matcher.find()) {
-				message = StringUtils.emptyIfNull(matcher.group(1));
+			message = readHtmlElementText(responseText, "font", true);
+			if (message != null) {
 				if (!message.contains("CAPTCHA")) {
 					break;
 				}

--- a/src/com/mishiranu/dashchan/chan/fourchan/FourchanModelMapper.java
+++ b/src/com/mishiranu/dashchan/chan/fourchan/FourchanModelMapper.java
@@ -12,10 +12,44 @@ import chan.util.StringUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 public class FourchanModelMapper {
-	private static final Pattern PATTERN_MATH = Pattern.compile("\\[(math|eqn)](.*?)\\[/\\1]");
+	private static String replaceMathTags(String comment, FourchanChanLocator locator) {
+		StringBuilder result = null;
+		int copyFrom = 0;
+		int searchFrom = 0;
+		while (true) {
+			int mathStart = comment.indexOf("[math]", searchFrom);
+			int eqnStart = comment.indexOf("[eqn]", searchFrom);
+			int start;
+			String closingTag;
+			if (mathStart >= 0 && (eqnStart < 0 || mathStart < eqnStart)) {
+				start = mathStart;
+				closingTag = "[/math]";
+			} else if (eqnStart >= 0) {
+				start = eqnStart;
+				closingTag = "[/eqn]";
+			} else {
+				break;
+			}
+			int contentStart = start + 6;
+			int end = comment.indexOf(closingTag, contentStart);
+			if (end < 0) {
+				searchFrom = contentStart;
+				continue;
+			}
+			String formula = StringUtils.clearHtml(comment.substring(contentStart, end));
+			String encodedFormula = formula.replace("<", "&lt;").replace(">", "&gt;");
+			String encodedUri = locator.buildMathUri(formula).toString().replace("\"", "&quot;");
+			if (result == null) result = new StringBuilder(comment.length());
+			result.append(comment, copyFrom, start).append("<a href=\"").append(encodedUri).append("\">")
+					.append(encodedFormula).append("</a>");
+			copyFrom = end + closingTag.length();
+			searchFrom = copyFrom;
+		}
+		if (result == null) return comment;
+		return result.append(comment, copyFrom, comment.length()).toString();
+	}
 
 	public static class Extra {
 		public int uniquePosters;
@@ -118,10 +152,7 @@ public class FourchanModelMapper {
 					}
 					String com = StringUtils.linkify(builder.toString());
 					if (handleMathTags && (com.contains("[math]") || com.contains("[eqn]"))) {
-						com = StringUtils.replaceAll(com, PATTERN_MATH, matcher -> "<a href=\"" +
-								locator.buildMathUri(StringUtils.clearHtml(matcher.group(2))).toString()
-										.replaceAll("\"", "&quot;") + "\">" + StringUtils.clearHtml(matcher.group(2))
-								.replaceAll("<", "&lt;").replaceAll(">", "&gt;") + "</a>");
+						com = replaceMathTags(com, locator);
 					}
 					post.setComment(com);
 					break;

--- a/src/com/mishiranu/dashchan/content/PostingShareActivity.java
+++ b/src/com/mishiranu/dashchan/content/PostingShareActivity.java
@@ -35,8 +35,7 @@ public class PostingShareActivity extends Activity {
 	}
 
 	private static boolean isStreamUri(Uri uri) {
-		return uri != null && ("content".equalsIgnoreCase(uri.getScheme())
-				|| "file".equalsIgnoreCase(uri.getScheme()));
+		return uri != null && "content".equalsIgnoreCase(uri.getScheme());
 	}
 
 	private static ArrayList<Uri> collectStreamUris(Intent intent) {
@@ -120,7 +119,8 @@ public class PostingShareActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		DraftsStorage draftsStorage = DraftsStorage.getInstance();
 		Intent intent = getIntent();
-		ArrayList<Uri> uris = collectStreamUris(intent);
+		ArrayList<Uri> uris = (intent.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION) != 0
+				? collectStreamUris(intent) : new ArrayList<>();
 		String sharedText = collectSharedText(intent);
 		Uri contentUri = findChanUri(sharedText);
 

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -23,6 +23,7 @@ import com.mishiranu.dashchan.content.translation.TranslationEngine;
 import com.mishiranu.dashchan.util.SharedPreferences;
 import com.mishiranu.dashchan.widget.ClickableToast;
 import java.io.File;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -33,7 +34,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -1365,12 +1365,12 @@ public class Preferences {
 	}
 
 	public static final ChanKey KEY_PASSWORD = new ChanKey("password");
+	private static final SecureRandom PASSWORD_RANDOM = new SecureRandom();
 
 	private static String generatePassword() {
 		StringBuilder password = new StringBuilder();
-		Random random = new Random(System.currentTimeMillis());
-		for (int i = 0, count = 10 + random.nextInt(6); i < count; i++) {
-			int value = random.nextInt(26 + 26 + 10);
+		for (int i = 0, count = 10 + PASSWORD_RANDOM.nextInt(6); i < count; i++) {
+			int value = PASSWORD_RANDOM.nextInt(26 + 26 + 10);
 			if (value < 26) {
 				value = 0x41 + value;
 			} else if (value < 26 + 26) {
@@ -1985,11 +1985,10 @@ public class Preferences {
 		}
 	}
 
-	public static final String KEY_VERIFY_CERTIFICATE = "verify_certificate";
-	public static final boolean DEFAULT_VERIFY_CERTIFICATE = true;
-
 	public static boolean isVerifyCertificate() {
-		return PREFERENCES.getBoolean(KEY_VERIFY_CERTIFICATE, DEFAULT_VERIFY_CERTIFICATE);
+		// Certificate and hostname verification is mandatory. The former opt-out
+		// exposed all HTTPS traffic to active interception.
+		return true;
 	}
 
 	public enum VideoCompletionMode {

--- a/src/com/mishiranu/dashchan/content/model/FileHolder.java
+++ b/src/com/mishiranu/dashchan/content/model/FileHolder.java
@@ -377,13 +377,17 @@ public abstract class FileHolder {
 			this.name = name;
 			if (calculateSize) {
 				try (InputStream input = openInputStream()) {
-					int newSize = 0;
+					long newSize = 0;
 					byte[] buffer = new byte[8192];
 					int count;
-					while ((count = input.read(buffer)) >= 0) {
+					while ((count = input.read(buffer)) != -1) {
 						newSize += count;
+						if (newSize > Integer.MAX_VALUE) {
+							newSize = -1;
+							break;
+						}
 					}
-					size = newSize;
+					size = (int) newSize;
 				} catch (IOException e) {
 					// Ignore
 				}
@@ -469,10 +473,10 @@ public abstract class FileHolder {
 
 	private static FileHolder obtain(Uri uri, boolean calculateSize) {
 		String scheme = uri.getScheme();
-		if ("file".equals(scheme)) {
-			String path = uri.getPath();
-			return new FileFileHolder(new File(path));
-		} else if ("content".equals(scheme)) {
+		// Uri instances accepted here originate outside the app (document picker,
+		// sharing or receive-content). Never turn an external file:// path into a
+		// File; internal files must use obtain(File), where the caller owns the path.
+		if ("content".equals(scheme)) {
 			try (Cursor cursor = MainApplication.getInstance()
 					.getContentResolver().query(uri, null, null, null, null)) {
 				if (cursor != null && cursor.moveToFirst()) {
@@ -480,7 +484,8 @@ public abstract class FileHolder {
 					int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
 					if (nameIndex >= 0 && (sizeIndex >= 0 || !calculateSize)) {
 						String name = cursor.getString(nameIndex);
-						int size = sizeIndex >= 0 ? cursor.getInt(sizeIndex) : -1;
+						long longSize = sizeIndex >= 0 ? cursor.getLong(sizeIndex) : -1;
+						int size = longSize >= 0 && longSize <= Integer.MAX_VALUE ? (int) longSize : -1;
 						if (StringUtils.isEmpty(name)) {
 							@SuppressWarnings("deprecation")
 							String column = MediaStore.MediaColumns.DATA;

--- a/src/com/mishiranu/dashchan/content/net/RecaptchaReader.java
+++ b/src/com/mishiranu/dashchan/content/net/RecaptchaReader.java
@@ -48,8 +48,9 @@ import com.mishiranu.dashchan.util.ViewUtils;
 import com.mishiranu.dashchan.util.WebViewUtils;
 import com.mishiranu.dashchan.widget.ScaledWebView;
 import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 
 public class RecaptchaReader {
 	private static final float EXTRA_SCALE_FOR_SYSTEM_PADDING = 0.8f;
@@ -63,11 +64,6 @@ public class RecaptchaReader {
 	private RecaptchaReader() {}
 
 	private final Object accessLock = new Object();
-
-	private static final Pattern RECAPTCHA_FALLBACK_PATTERN = Pattern.compile("(?:(?:<div " +
-			"class=\"(?:rc-imageselect-desc(?:-no-canonical)?|fbc-imageselect-message-error)\">)(.*?)" +
-			"</div>.*?)?value=\"(.{20,}?)\"");
-	private static final Pattern RECAPTCHA_RESULT_PATTERN = Pattern.compile("<textarea.*?>(.*?)</textarea>");
 
 	public static class ChallengeExtra {
 		private interface ForegroundSolver {
@@ -106,10 +102,22 @@ public class RecaptchaReader {
 	}
 
 	private static Pair<String, String> parseResponse2(String responseText) {
-		Matcher matcher = RECAPTCHA_FALLBACK_PATTERN.matcher(responseText);
-		if (matcher.find()) {
-			String imageSelectorDescription = matcher.group(1);
-			String challenge = matcher.group(2);
+		if (StringUtils.isEmpty(responseText)) {
+			return null;
+		}
+		Document document = Jsoup.parse(responseText);
+		Element description = document.selectFirst(".rc-imageselect-desc, .rc-imageselect-desc-no-canonical, " +
+				".fbc-imageselect-message-error");
+		Element challengeInput = document.selectFirst("input[name=c][value]");
+		if (challengeInput == null) {
+			challengeInput = document.selectFirst("input[value]");
+		}
+		if (challengeInput != null) {
+			String challenge = challengeInput.attr("value");
+			if (challenge.length() < 20) {
+				return null;
+			}
+			String imageSelectorDescription = description != null ? description.html() : null;
 			return new Pair<>(imageSelectorDescription, challenge);
 		}
 		return null;
@@ -208,9 +216,10 @@ public class RecaptchaReader {
 									.addHeader("Accept-Language", acceptLanguage)
 									.addHeader("Referer", referer)
 									.perform().readString();
-							Matcher matcher = RECAPTCHA_RESULT_PATTERN.matcher(responseText);
-							if (matcher.find()) {
-								return matcher.group(1);
+							Element resultElement = !StringUtils.isEmpty(responseText)
+									? Jsoup.parse(responseText).selectFirst("textarea") : null;
+							if (resultElement != null) {
+								return resultElement.text();
 							}
 							response = parseResponse2(responseText);
 							continue;

--- a/src/com/mishiranu/dashchan/content/net/firewall/StormWallResolver.java
+++ b/src/com/mishiranu/dashchan/content/net/firewall/StormWallResolver.java
@@ -11,8 +11,6 @@ import chan.util.StringUtils;
 import com.mishiranu.dashchan.content.Preferences;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class StormWallResolver extends FirewallResolver {
 	private static final String COOKIE_STORMWALL = "swp_token";
@@ -60,8 +58,42 @@ public class StormWallResolver extends FirewallResolver {
 		}
 	}
 
-	private static final Pattern PATTERN_CE = Pattern.compile(" cE ?= ?(['\"])(.*?)\\1");
-	private static final Pattern PATTERN_CK = Pattern.compile(" cK ?= ?(?:(['\"])|)(.*?)(?:\\1|;)");
+	private static String findAssignment(String source, String name, boolean quotedOnly) {
+		String marker = " " + name;
+		int fromIndex = 0;
+		while (true) {
+			int start = source.indexOf(marker, fromIndex);
+			if (start < 0) {
+				return null;
+			}
+			int index = start + marker.length();
+			while (index < source.length() && source.charAt(index) == ' ') {
+				index++;
+			}
+			if (index >= source.length() || source.charAt(index) != '=') {
+				fromIndex = start + marker.length();
+				continue;
+			}
+			index++;
+			while (index < source.length() && source.charAt(index) == ' ') {
+				index++;
+			}
+			if (index >= source.length()) {
+				return null;
+			}
+			char quote = source.charAt(index);
+			if (quote == '\'' || quote == '\"') {
+				int end = source.indexOf(quote, index + 1);
+				return end >= 0 ? source.substring(index + 1, end) : null;
+			}
+			if (quotedOnly) {
+				fromIndex = index + 1;
+				continue;
+			}
+			int end = source.indexOf(';', index);
+			return source.substring(index, end >= 0 ? end : source.length()).trim();
+		}
+	}
 
 	private static String calculateCookie(String ce, int ck) {
 		StringBuilder result = new StringBuilder();
@@ -84,11 +116,9 @@ public class StormWallResolver extends FirewallResolver {
 
 		@Override
 		public boolean resolve(Session session, Key key) throws CancelException, HttpException, InterruptedException {
-			Matcher ceMatcher = PATTERN_CE.matcher(responseText);
-			Matcher ckMatcher = PATTERN_CK.matcher(responseText);
-			if (ceMatcher.find() && ckMatcher.find()) {
-				String ce = StringUtils.emptyIfNull(ceMatcher.group(2));
-				String ckString = StringUtils.emptyIfNull(ckMatcher.group(2));
+			String ce = StringUtils.emptyIfNull(findAssignment(responseText, "cE", true));
+			String ckString = StringUtils.emptyIfNull(findAssignment(responseText, "cK", false));
+			if (!ce.isEmpty() && !ckString.isEmpty()) {
 				Integer ck = null;
 				try {
 					ck = Integer.parseInt(ckString);

--- a/src/com/mishiranu/dashchan/content/storage/DraftsStorage.java
+++ b/src/com/mishiranu/dashchan/content/storage/DraftsStorage.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 public class DraftsStorage extends StorageManager.Storage<Pair<List<DraftsStorage.PostDraft>,
 		List<DraftsStorage.AttachmentDraft>>> {
+	private static final int ATTACHMENT_HASH_LENGTH = 64;
 	private static final String KEY_POST_DRAFTS = "postDrafts";
 	private static final String KEY_FUTURE_ATTACHMENT_DRAFTS = "futureAttachmentDrafts";
 
@@ -204,8 +205,15 @@ public class DraftsStorage extends StorageManager.Storage<Pair<List<DraftsStorag
 	}
 
 	private static File resolveAttachmentDraftFile(String hash) {
+		if (!isAttachmentDraftHash(hash)) {
+			return null;
+		}
 		File directory = getAttachmentDraftsDirectory();
 		return directory != null ? new File(directory, hash) : null;
+	}
+
+	private static boolean isAttachmentDraftHash(String hash) {
+		return hash != null && hash.length() == ATTACHMENT_HASH_LENGTH && hash.matches("[0-9a-f]{64}");
 	}
 
 	public File getAttachmentDraftFile(String hash) {
@@ -823,7 +831,7 @@ public class DraftsStorage extends StorageManager.Storage<Pair<List<DraftsStorag
 					}
 				}
 			}
-			if (StringUtils.isEmpty(hash)) {
+			if (!isAttachmentDraftHash(hash)) {
 				return null;
 			}
 			return new AttachmentDraft(hash, name, rating, optionUniqueHash, optionRemoveMetadata,

--- a/src/com/mishiranu/dashchan/content/update/GitHubReleaseFallback.java
+++ b/src/com/mishiranu/dashchan/content/update/GitHubReleaseFallback.java
@@ -2,19 +2,12 @@ package com.mishiranu.dashchan.content.update;
 
 import chan.util.StringUtils;
 import com.mishiranu.dashchan.BuildConfig;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Locale;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class GitHubReleaseFallback {
-	private static final Pattern[] VERSION_CODE_PATTERNS = {
-			Pattern.compile("(?i)\\bversion\\s*code\\b\\s*[:=#-]?\\s*(\\d{3,})"),
-			Pattern.compile("(?i)\\bcode\\b\\s*[:=#-]?\\s*(\\d{3,})"),
-			Pattern.compile("(?i)(?:^|[-_])(?:beta|test)[-_]?(\\d{3,})\\b")
-	};
-
 	public static UpdateResult check(String releasesUrl, String latestReleaseUrl,
 			boolean includePrereleases) throws Exception {
 		if (!StringUtils.isEmpty(releasesUrl)) {
@@ -78,17 +71,91 @@ public class GitHubReleaseFallback {
 	private static Integer extractVersionCode(String... values) {
 		for (String value : values) {
 			if (!StringUtils.isEmpty(value)) {
-				for (Pattern pattern : VERSION_CODE_PATTERNS) {
-					Matcher matcher = pattern.matcher(value);
-					if (matcher.find()) {
-						try {
-							return Integer.parseInt(matcher.group(1));
-						} catch (NumberFormatException e) {
-							// Try the next pattern/source.
-						}
-					}
-				}
+				String lower = value.toLowerCase(Locale.US);
+				Integer code = extractLabeledNumber(value, lower, "version", "code");
+				if (code == null) code = extractLabeledNumber(value, lower, "code");
+				if (code == null) code = extractChannelNumber(value, lower, "beta");
+				if (code == null) code = extractChannelNumber(value, lower, "test");
+				if (code != null) return code;
 			}
+		}
+		return null;
+	}
+
+	private static boolean isWordCharacter(char c) {
+		return Character.isLetterOrDigit(c) || c == '_';
+	}
+
+	private static int skipWhitespace(String value, int index) {
+		while (index < value.length() && Character.isWhitespace(value.charAt(index))) index++;
+		return index;
+	}
+
+	private static Integer parseNumber(String value, int start) {
+		int end = start;
+		while (end < value.length() && value.charAt(end) >= '0' && value.charAt(end) <= '9') end++;
+		if (end - start < 3 || end < value.length() && isWordCharacter(value.charAt(end))) return null;
+		try {
+			return Integer.parseInt(value.substring(start, end));
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private static Integer extractLabeledNumber(String value, String lower, String... words) {
+		int fromIndex = 0;
+		while (fromIndex < lower.length()) {
+			int index = lower.indexOf(words[0], fromIndex);
+			if (index < 0) return null;
+			if (index > 0 && isWordCharacter(lower.charAt(index - 1))) {
+				fromIndex = index + 1;
+				continue;
+			}
+			int end = index + words[0].length();
+			if (end < lower.length() && isWordCharacter(lower.charAt(end))) {
+				fromIndex = index + 1;
+				continue;
+			}
+			boolean matches = true;
+			for (int i = 1; i < words.length; i++) {
+				int separatorStart = end;
+				end = skipWhitespace(lower, end);
+				if (end == separatorStart) {
+					matches = false;
+					break;
+				}
+				String word = words[i];
+				if (!lower.startsWith(word, end) || end + word.length() < lower.length() &&
+						isWordCharacter(lower.charAt(end + word.length()))) {
+					matches = false;
+					break;
+				}
+				end += word.length();
+			}
+			if (matches) {
+				end = skipWhitespace(lower, end);
+				if (end < lower.length() && ":=#-".indexOf(lower.charAt(end)) >= 0) end++;
+				end = skipWhitespace(lower, end);
+				Integer number = parseNumber(value, end);
+				if (number != null) return number;
+			}
+			fromIndex = index + 1;
+		}
+		return null;
+	}
+
+	private static Integer extractChannelNumber(String value, String lower, String channel) {
+		int fromIndex = 0;
+		while (fromIndex < lower.length()) {
+			int index = lower.indexOf(channel, fromIndex);
+			if (index < 0) return null;
+			if (index == 0 || lower.charAt(index - 1) == '-' || lower.charAt(index - 1) == '_') {
+				int end = index + channel.length();
+				if (end < lower.length() && (lower.charAt(end) == '-' || lower.charAt(end) == '_')) end++;
+				Integer number = parseNumber(value, end);
+				if (number != null) return number;
+			}
+			fromIndex = index + 1;
 		}
 		return null;
 	}
@@ -97,12 +164,18 @@ public class GitHubReleaseFallback {
 		if (StringUtils.isEmpty(value)) {
 			return null;
 		}
-		String[] lines = value.split("\\r?\\n");
-		for (String line : lines) {
+		int start = 0;
+		while (start <= value.length()) {
+			int end = value.indexOf('\n', start);
+			if (end < 0) end = value.length();
+			String line = value.substring(start, end);
+			if (line.endsWith("\r")) line = line.substring(0, line.length() - 1);
 			line = line.trim();
 			if (!line.isEmpty()) {
 				return line.length() > 240 ? line.substring(0, 240) : line;
 			}
+			if (end == value.length()) break;
+			start = end + 1;
 		}
 		return null;
 	}

--- a/src/com/mishiranu/dashchan/content/update/UpdateChecker.java
+++ b/src/com/mishiranu/dashchan/content/update/UpdateChecker.java
@@ -6,7 +6,6 @@ import com.mishiranu.dashchan.BuildConfig;
 import com.mishiranu.dashchan.content.Preferences;
 import com.mishiranu.dashchan.content.async.ExecutorTask;
 import com.mishiranu.dashchan.util.ConcurrentUtils;
-import com.mishiranu.dashchan.util.IOUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +16,7 @@ import org.json.JSONException;
 
 public class UpdateChecker {
 	private static final int TIMEOUT_MS = 10_000;
+	private static final int MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 	private static final String USER_AGENT = "Dashchan_2 UpdateChecker";
 
 	public interface Callback {
@@ -147,7 +147,14 @@ public class UpdateChecker {
 			}
 			try (InputStream input = rawConnection.getInputStream();
 					ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-				IOUtils.copyStream(input, output);
+				byte[] buffer = new byte[8192];
+				int total = 0;
+				int count;
+				while ((count = input.read(buffer)) != -1) {
+					total += count;
+					if (total > MAX_RESPONSE_BYTES) throw new IOException("Update response is too large");
+					output.write(buffer, 0, count);
+				}
 				return output.toString("UTF-8");
 			}
 		} finally {

--- a/src/com/mishiranu/dashchan/media/AnimatedPngDecoder.java
+++ b/src/com/mishiranu/dashchan/media/AnimatedPngDecoder.java
@@ -317,15 +317,13 @@ public class AnimatedPngDecoder implements Runnable {
 
 		@Override
 		public long skip(long byteCount) {
-			int totalCount = getTotalCount();
-			int left = totalCount - position;
-			if (left < byteCount) {
-				position = totalCount;
-				return left;
-			} else {
-				position += byteCount;
-				return byteCount;
+			if (byteCount <= 0) {
+				return 0;
 			}
+			int left = Math.max(getTotalCount() - position, 0);
+			int count = (int) Math.min((long) left, byteCount);
+			position += count;
+			return count;
 		}
 
 		@Override

--- a/src/com/mishiranu/dashchan/ui/posting/PostingFragment.java
+++ b/src/com/mishiranu/dashchan/ui/posting/PostingFragment.java
@@ -1524,6 +1524,10 @@ public class PostingFragment extends ContentFragment implements FragmentHandler.
 					if (data == null) {
 						break;
 					}
+					if ((data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION) == 0) {
+						ClickableToast.show(R.string.no_access_to_memory);
+						break;
+					}
 					LinkedHashSet<Uri> uris = new LinkedHashSet<>();
 					Uri dataUri = data.getData();
 					if (dataUri != null) {
@@ -2128,13 +2132,13 @@ public class PostingFragment extends ContentFragment implements FragmentHandler.
 		String selectedText = text.substring(selectionStart, selectionEnd);
 		String oneSymbolBefore = text.substring(Math.max(selectionStart - 1, 0), selectionStart);
 		if (selectedText.startsWith(">")) {
-			String unQuotedText = selectedText.replaceFirst("> ?", "").replaceAll("(\n+)> ?", "$1");
+			String unQuotedText = removeQuoteMarkers(selectedText);
 			int diff = selectedText.length() - unQuotedText.length();
 			editable.replace(selectionStart, selectionEnd, unQuotedText);
 			commentView.setSelection(selectionStart, selectionEnd - diff);
 		} else {
 			String firstSymbol = oneSymbolBefore.length() == 0 || oneSymbolBefore.equals("\n") ? "" : "\n";
-			String quotedText = firstSymbol + "> " + selectedText.replaceAll("(\n+)", "$1> ");
+			String quotedText = firstSymbol + "> " + addQuoteMarkers(selectedText);
 			int diff = quotedText.length() - selectedText.length();
 			editable.replace(selectionStart, selectionEnd, quotedText);
 			int newStart = selectionStart + firstSymbol.length();
@@ -2144,6 +2148,34 @@ public class PostingFragment extends ContentFragment implements FragmentHandler.
 			}
 			commentView.setSelection(newStart, newEnd);
 		}
+	}
+
+	private static String addQuoteMarkers(String text) {
+		StringBuilder builder = new StringBuilder(text.length());
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			builder.append(c);
+			if (c == '\n' && (i + 1 == text.length() || text.charAt(i + 1) != '\n')) builder.append("> ");
+		}
+		return builder.toString();
+	}
+
+	private static String removeQuoteMarkers(String text) {
+		StringBuilder builder = new StringBuilder(text.length());
+		boolean lineStart = true;
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			if (lineStart && c == '>') {
+				if (i + 1 < text.length() && text.charAt(i + 1) == ' ') {
+					i++;
+				}
+				lineStart = false;
+				continue;
+			}
+			builder.append(c);
+			lineStart = c == '\n';
+		}
+		return builder.toString();
 	}
 
 	private void resizeComment(boolean post) {

--- a/src/com/mishiranu/dashchan/ui/preference/GeneralFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/GeneralFragment.java
@@ -82,8 +82,6 @@ public class GeneralFragment extends PreferenceFragment implements FragmentHandl
 		addButton(0, R.string.specific_to_internal_services__sentence).setSelectable(false);
 		addCheck(true, Preferences.KEY_USE_HTTPS_GENERAL, Preferences.DEFAULT_USE_HTTPS,
 				R.string.secure_connection, R.string.secure_connection__summary);
-		addCheck(true, Preferences.KEY_VERIFY_CERTIFICATE, Preferences.DEFAULT_VERIFY_CERTIFICATE,
-				R.string.verify_certificate, R.string.verify_certificate__summary);
 	}
 
 	@Override

--- a/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
+++ b/src/com/mishiranu/dashchan/ui/preference/SettingsSearchIndex.java
@@ -303,8 +303,6 @@ public final class SettingsSearchIndex {
 				Preferences.KEY_CAPTCHA_SOLVING);
 		add(context, entries, Screen.GENERAL, R.string.secure_connection, R.string.secure_connection__summary,
 				Preferences.KEY_USE_HTTPS_GENERAL);
-		add(context, entries, Screen.GENERAL, R.string.verify_certificate, R.string.verify_certificate__summary,
-				Preferences.KEY_VERIFY_CERTIFICATE);
 
 		add(context, entries, Screen.EXPERIMENTAL, R.string.whats_new_preview,
 				R.string.whats_new_preview__summary, null);

--- a/src/com/mishiranu/dashchan/ui/preference/ThemesFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/ThemesFragment.java
@@ -2,6 +2,7 @@ package com.mishiranu.dashchan.ui.preference;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -36,7 +37,6 @@ import com.mishiranu.dashchan.ui.DialogMenu;
 import com.mishiranu.dashchan.ui.FragmentHandler;
 import com.mishiranu.dashchan.ui.preference.core.Preference;
 import com.mishiranu.dashchan.util.ConcurrentUtils;
-import com.mishiranu.dashchan.util.IOUtils;
 import com.mishiranu.dashchan.util.ListViewUtils;
 import com.mishiranu.dashchan.util.ViewUtils;
 import com.mishiranu.dashchan.widget.ClickableToast;
@@ -59,6 +59,7 @@ import org.json.JSONObject;
 
 public class ThemesFragment extends BaseListFragment {
 	private static final String EXTRA_AVAILABLE_THEMES = "availableThemes";
+	private static final int MAX_IMPORTED_THEME_BYTES = 1024 * 1024;
 	private static final String URI_TRIXI_THEMES = "//raw.githubusercontent.com/" +
 			"TrixiEther/Dashchan-Meta/master/update/themes.json";
 
@@ -165,23 +166,21 @@ public class ThemesFragment extends BaseListFragment {
 		if (resultCode == Activity.RESULT_OK && data != null) {
 			switch (requestCode) {
 				case C.REQUEST_CODE_ATTACH: {
+					if ((data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION) == 0) {
+						ClickableToast.show(R.string.no_access_to_memory);
+						break;
+					}
 					Uri uri = data.getData();
 					if (uri != null) {
-						ByteArrayOutputStream output = new ByteArrayOutputStream();
-						boolean success;
-						try (InputStream input = requireContext().getContentResolver().openInputStream(uri)) {
-							if (input == null) {
-								throw new IOException("Input stream is empty");
-							}
-							IOUtils.copyStream(input, output);
-							success = true;
+						byte[] array;
+						try {
+							array = readImportedTheme(requireContext().getContentResolver(), uri);
 						} catch (IOException | SecurityException e) {
 							e.printStackTrace();
-							success = false;
+							array = null;
 							ClickableToast.show(R.string.no_access_to_memory);
 						}
-						byte[] array = output.toByteArray();
-						if (success && array.length > 0) {
+						if (array != null && array.length > 0) {
 							JSONObject jsonObject;
 							try {
 								jsonObject = new JSONObject(new String(array, StandardCharsets.UTF_8));
@@ -195,13 +194,34 @@ public class ThemesFragment extends BaseListFragment {
 							} else {
 								ClickableToast.show(R.string.invalid_data_format);
 							}
-						} else if (success) {
+						} else if (array != null) {
 							ClickableToast.show(R.string.invalid_data_format);
 						}
 					}
 					break;
 				}
 			}
+		}
+	}
+
+	private static byte[] readImportedTheme(ContentResolver resolver, Uri uri) throws IOException {
+		if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+			return new byte[0];
+		}
+		try (InputStream input = resolver.openInputStream(uri)) {
+			if (input == null) {
+				throw new IOException("Input stream is empty");
+			}
+			ByteArrayOutputStream output = new ByteArrayOutputStream();
+			byte[] buffer = new byte[8192];
+			int count;
+			while ((count = input.read(buffer)) != -1) {
+				if (count > MAX_IMPORTED_THEME_BYTES - output.size()) {
+					return new byte[0];
+				}
+				output.write(buffer, 0, count);
+			}
+			return output.toByteArray();
 		}
 	}
 

--- a/src/com/mishiranu/dashchan/ui/preference/ThemesFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/ThemesFragment.java
@@ -208,6 +208,11 @@ public class ThemesFragment extends BaseListFragment {
 		if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
 			return new byte[0];
 		}
+		String path = uri.getPath();
+		if (StringUtils.isEmpty(uri.getAuthority()) || path == null || path.contains("..")
+				|| path.startsWith("/data")) {
+			return new byte[0];
+		}
 		try (InputStream input = resolver.openInputStream(uri)) {
 			if (input == null) {
 				throw new IOException("Input stream is empty");

--- a/src/com/mishiranu/dashchan/widget/DividerItemDecoration.java
+++ b/src/com/mishiranu/dashchan/widget/DividerItemDecoration.java
@@ -81,7 +81,7 @@ public class DividerItemDecoration extends RecyclerView.ItemDecoration {
 
 	private void drawDivider(Canvas canvas, int top, int left, int right, int height, View view, boolean translate) {
 		if (translate) {
-			top += view.getTranslationY();
+			top += Math.round(view.getTranslationY());
 		}
 		drawable.setBounds(left, top, right, top + height);
 		drawable.draw(canvas);


### PR DESCRIPTION
## Summary

- replace potentially expensive regex parsing with bounded DOM or linear parsing for board data, captcha responses, StormWall challenges, and GitHub release metadata
- enforce normal TLS certificate and hostname verification and use `SecureRandom` for generated posting passwords
- validate externally supplied content URIs, attachment draft names, imported themes, and update response sizes
- harden GIF, APNG, audio, and video native size calculations against overflow and invalid dimensions
- preserve existing behavior for supported boards, posting, themes, updates, and media playback

## Validation

- `git diff --check` passes
- the source archive builds successfully after correcting the GIF scope and reCAPTCHA local-name compilation errors
- the resulting APK was manually tested for boards, media playback, posting attachments, captcha, themes, and updates
- no changes to application version, AndroidManifest, permissions, Gradle dependencies, release metadata, F-Droid, beta, Firebase backend, or cloud infrastructure

This PR intentionally remains a draft until GitHub CI and code scanning complete.